### PR TITLE
chore: clean up import order and literal typing

### DIFF
--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -1,8 +1,9 @@
 import logging
+
+from typing import cast
 from typing import Iterable
 from typing import List
 from typing import Tuple
-from typing import cast
 
 from google.protobuf.message import Message
 from grpc.aio import AioRpcError

--- a/frontrunner_sdk/clients/injective_faucet.py
+++ b/frontrunner_sdk/clients/injective_faucet.py
@@ -1,5 +1,6 @@
 import json
 import logging
+
 from typing import Optional
 
 import aiohttp

--- a/frontrunner_sdk/clients/injective_light_client_daemon.py
+++ b/frontrunner_sdk/clients/injective_light_client_daemon.py
@@ -1,4 +1,5 @@
 import logging
+
 from typing import Optional
 
 from frontrunner_sdk.exceptions import FrontrunnerConfigurationException

--- a/frontrunner_sdk/config/base.py
+++ b/frontrunner_sdk/config/base.py
@@ -1,11 +1,16 @@
+import typing
+
 from typing import Literal
 from typing import Optional
+
+NetworkEnvironment = Literal["devnet", "testnet", "mainnet"]
+NETWORK_ENVIRONMENTS = set(typing.get_args(NetworkEnvironment))
 
 
 class FrontrunnerConfig:
 
   @property
-  def injective_network(self) -> Optional[Literal["devnet", "testnet", "mainnet"]]:
+  def injective_network(self) -> Optional[NetworkEnvironment]:
     return None
 
   @property

--- a/frontrunner_sdk/config/chained.py
+++ b/frontrunner_sdk/config/chained.py
@@ -1,10 +1,10 @@
 from typing import Callable
 from typing import List
-from typing import Literal
 from typing import Optional
 from typing import TypeVar
 
 from frontrunner_sdk.config.base import FrontrunnerConfig
+from frontrunner_sdk.config.base import NetworkEnvironment
 
 T = TypeVar("T")
 
@@ -24,7 +24,7 @@ class ChainedFrontrunnerConfig(FrontrunnerConfig):
     return None
 
   @property
-  def injective_network(self) -> Optional[Literal["devnet", "testnet", "mainnet"]]:
+  def injective_network(self) -> Optional[NetworkEnvironment]:
     return self._find_next(lambda config: config.injective_network)
 
   @property

--- a/frontrunner_sdk/config/static.py
+++ b/frontrunner_sdk/config/static.py
@@ -1,13 +1,13 @@
 from dataclasses import dataclass
-from typing import Literal
 from typing import Optional
 
 from frontrunner_sdk.config.base import FrontrunnerConfig
+from frontrunner_sdk.config.base import NetworkEnvironment
 
 
 @dataclass(frozen=True)
 class StaticFrontrunnerConfig(FrontrunnerConfig):
-  injective_network: Optional[Literal["devnet", "testnet", "mainnet"]] = None
+  injective_network: Optional[NetworkEnvironment] = None
   injective_chain_id: Optional[str] = None
   injective_exchange_authority: Optional[str] = None
   injective_explorer_authority: Optional[str] = None

--- a/frontrunner_sdk/logging/log_external_exceptions.py
+++ b/frontrunner_sdk/logging/log_external_exceptions.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+
 from typing import Any
 from typing import Awaitable
 from typing import Callable

--- a/frontrunner_sdk/logging/log_operation.py
+++ b/frontrunner_sdk/logging/log_operation.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+
 from typing import Awaitable
 from typing import Callable
 from typing import TypeVar

--- a/frontrunner_sdk/sync.py
+++ b/frontrunner_sdk/sync.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from typing import Any
 from typing import Awaitable
 from typing import Callable

--- a/tests/clients/test_injective_faucet.py
+++ b/tests/clients/test_injective_faucet.py
@@ -1,4 +1,5 @@
 import json
+
 from unittest.mock import patch
 
 from aiohttp import ClientError

--- a/tests/logging/test_log_external_exceptions.py
+++ b/tests/logging/test_log_external_exceptions.py
@@ -1,4 +1,5 @@
 import logging
+
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import patch
 

--- a/tests/logging/test_log_operation.py
+++ b/tests/logging/test_log_operation.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import MagicMock
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,5 @@
 import asyncio
+
 from typing import Any
 from typing import Dict
 from typing import List

--- a/tox.ini
+++ b/tox.ini
@@ -6,9 +6,10 @@ ban-relative-imports = true
 inline-quotes = double
 
 [isort]
-force_sort_within_sections = true
+force_alphabetical_sort_within_sections = true
 remove_redundant_aliases = true
 group_by_package = true
 force_single_line = true
 multi_line_output = 7
+lines_between_types = 1
 wrap_length = 0


### PR DESCRIPTION
Changes:
* `force_alphabetical_sort_within_sections` since it seperates raw import (`import os`) and from imports (`from os import ...`)
* Make a literal type for dev/test/main net