### PR TITLE
feat: add conditional config

### DIFF
--- a/frontrunner_sdk/config/__init__.py
+++ b/frontrunner_sdk/config/__init__.py
@@ -2,13 +2,11 @@ import os
 
 from frontrunner_sdk.config.base import FrontrunnerConfig
 from frontrunner_sdk.config.chained import ChainedFrontrunnerConfig
+from frontrunner_sdk.config.conditional import ConditionalFrontrunnerConfig
 from frontrunner_sdk.config.environment_variable import EnvironmentVariableFrontrunnerConfig  # NOQA
 from frontrunner_sdk.config.static import StaticFrontrunnerConfig
 
 DEFAULT_FRONTRUNNER_CONFIG: FrontrunnerConfig = ChainedFrontrunnerConfig([
-
-  # TODO hardcoding as proof of concept, will have other configs later. For
-  # now, comment out what you need.
   EnvironmentVariableFrontrunnerConfig(os.environ),
 
   # testnet
@@ -19,12 +17,15 @@ DEFAULT_FRONTRUNNER_CONFIG: FrontrunnerConfig = ChainedFrontrunnerConfig([
   ),
 
   # injective k8s network
-  StaticFrontrunnerConfig(
-    injective_exchange_authority="k8s.testnet.exchange.grpc.injective.network:443",
-    injective_explorer_authority="k8s.testnet.explorer.grpc.injective.network:443",
-    injective_grpc_authority="k8s.testnet.chain.grpc.injective.network:443",
-    injective_lcd_base_url="https://k8s.testnet.lcd.injective.network",
-    injective_rpc_base_url="wss://k8s.testnet.tm.injective.network/websocket",
+  ConditionalFrontrunnerConfig(
+    lambda: os.environ.get("FRONTRUNNER_PRESET_NODES") == "injective",
+    StaticFrontrunnerConfig(
+      injective_exchange_authority="k8s.testnet.exchange.grpc.injective.network:443",
+      injective_explorer_authority="k8s.testnet.explorer.grpc.injective.network:443",
+      injective_grpc_authority="k8s.testnet.chain.grpc.injective.network:443",
+      injective_lcd_base_url="https://k8s.testnet.lcd.injective.network",
+      injective_rpc_base_url="wss://k8s.testnet.tm.injective.network/websocket",
+    )
   ),
 
   # frontrunner network

--- a/frontrunner_sdk/config/conditional.py
+++ b/frontrunner_sdk/config/conditional.py
@@ -1,0 +1,44 @@
+from typing import Callable
+from typing import Optional
+
+from frontrunner_sdk.config.base import FrontrunnerConfig
+from frontrunner_sdk.config.base import NetworkEnvironment
+
+
+class ConditionalFrontrunnerConfig(FrontrunnerConfig):
+
+  def __init__(self, condition: Callable[[], bool], config: FrontrunnerConfig):
+    self.condition = condition
+    self.config = config
+
+  @property
+  def injective_network(self) -> Optional[NetworkEnvironment]:
+    return self.config.injective_network if self.condition() else None
+
+  @property
+  def injective_chain_id(self) -> Optional[str]:
+    return self.config.injective_chain_id if self.condition() else None
+
+  @property
+  def injective_exchange_authority(self) -> Optional[str]:
+    return self.config.injective_exchange_authority if self.condition() else None
+
+  @property
+  def injective_explorer_authority(self) -> Optional[str]:
+    return self.config.injective_explorer_authority if self.condition() else None
+
+  @property
+  def injective_grpc_authority(self) -> Optional[str]:
+    return self.config.injective_grpc_authority if self.condition() else None
+
+  @property
+  def injective_lcd_base_url(self) -> Optional[str]:
+    return self.config.injective_lcd_base_url if self.condition() else None
+
+  @property
+  def injective_rpc_base_url(self) -> Optional[str]:
+    return self.config.injective_rpc_base_url if self.condition() else None
+
+  @property
+  def injective_faucet_base_url(self) -> Optional[str]:
+    return self.config.injective_faucet_base_url if self.condition() else None

--- a/tests/config/test_conditional.py
+++ b/tests/config/test_conditional.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from frontrunner_sdk.config.conditional import ConditionalFrontrunnerConfig
+from frontrunner_sdk.config.static import StaticFrontrunnerConfig
+
+
+class TestConditionalFrontrunnerConfig(TestCase):
+
+  def setUp(self):
+    self.base = StaticFrontrunnerConfig(injective_exchange_authority="authority")
+
+  def test_conditional_true(self):
+    config = ConditionalFrontrunnerConfig(lambda: True, self.base)
+    self.assertEqual(config.injective_exchange_authority, "authority")
+
+  def test_conditional_false(self):
+    config = ConditionalFrontrunnerConfig(lambda: False, self.base)
+    self.assertIsNone(config.injective_exchange_authority)


### PR DESCRIPTION
# Testing

Ran the following code under...

* `pants repl ::`
* `FRONTRUNNER_PRESET_NODES=injective pants repl ::`

```python
from frontrunner_sdk import FrontrunnerSDK
fr = FrontrunnerSDK()
wallet = fr.injective.load_wallet_from_mnemonic("<words>").wallet # replace words w/ mnemonic
```

Under both cases, the load works. Load wallet calls out to the LCD endpoint for initialization.