### PR TITLE
fix: send wallet to to faucet client, not inj addr

### DIFF
--- a/frontrunner_sdk/commands/injective/fund_wallet_from_faucet.py
+++ b/frontrunner_sdk/commands/injective/fund_wallet_from_faucet.py
@@ -26,5 +26,5 @@ class FundWalletFromFaucetOperation(FrontrunnerOperation[FundWalletFromFaucetReq
 
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> FundWalletFromFaucetResponse:
-    response = await deps.injective_faucet.fund_wallet(self.request.wallet.injective_address)
+    response = await deps.injective_faucet.fund_wallet(self.request.wallet)
     return FundWalletFromFaucetResponse(message=response["message"])

--- a/frontrunner_sdk/logging/log_external_exceptions.py
+++ b/frontrunner_sdk/logging/log_external_exceptions.py
@@ -14,6 +14,20 @@ Result = TypeVar("Result")
 def log_external_exceptions(module_name: str):
   logger = logging.getLogger(module_name)
 
+  # Ideally, we don't use `...` as the parameter specification becaues if the
+  # caller to the underlying function messes up the types, there's no way to
+  # detect it. Params are basically treated as `Any`. There's a PEP that
+  # introduces support for parameter types. However, it's for Python 3.10+, and
+  # we're supporting 3.8+, so we can't "use" it.
+  #
+  # If we _could_ use it, this would be typed as:
+  #
+  #   Params = ParamSpec("Params")
+  #   def decorator(callable: Callable[Params, Awaitable[Result]]) -> Callable[Params, Awaitable[Result]]:
+  #     # ...
+  #
+  # https://stackoverflow.com/a/47060298
+  # https://peps.python.org/pep-0612/
   def logged_callable(callable: Callable[..., Awaitable[Result]]):
 
     @functools.wraps(callable)


### PR DESCRIPTION
Wasn't caught by type checking because it's wrapped as `Callable[..., Awaitable[Return]]`, which blows away any parameter typing. There's a PEP released that handles this, but it's only available for Python 3.10+.