### PR TITLE
fix: dependency inference warnings

### DIFF
--- a/tests/clients/test_injective_chain.py
+++ b/tests/clients/test_injective_chain.py
@@ -4,12 +4,12 @@ from unittest.mock import MagicMock
 
 from grpc import StatusCode
 from grpc.aio import AioRpcError
-from pyinjective.async_client import AsyncClient # NOQA
-from pyinjective.composer import Composer # NOQA
-from pyinjective.constant import Network # NOQA
-from pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2 import GasInfo
+from pyinjective.async_client import AsyncClient
+from pyinjective.composer import Composer
+from pyinjective.constant import Network
+from pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2 import GasInfo # NOQA
 from pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2 import SimulationResponse # NOQA
-from pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2 import TxResponse
+from pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2 import TxResponse # NOQA
 from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import DerivativeOrder # NOQA
 from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import OrderInfo
 from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import OrderType


### PR DESCRIPTION
Without this, we get a ton of spew during pants runs like this:

```
10:16:35.46 [WARN] Pants cannot infer owners for the following imports in the target frontrunner_sdk/clients/injective_chain.py:

  * pyinjective.async_client.AsyncClient (line: 10)
  * pyinjective.composer.Composer (line: 11)
  * pyinjective.constant.Denom (line: 12)
  * pyinjective.constant.Network (line: 13)
  * pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2.SimulationResponse (line: 14)
  * pyinjective.proto.cosmos.base.abci.v1beta1.abci_pb2.TxResponse (line: 15)
  * pyinjective.transaction.Coin (line: 16)
  * pyinjective.transaction.Transaction (line: 17)
```

This makes it quiet.