### PR TITLE
fix: don't show wallet mnemonic, private key

### DIFF
--- a/frontrunner_sdk/models/wallet.py
+++ b/frontrunner_sdk/models/wallet.py
@@ -7,7 +7,7 @@ from pyinjective import PrivateKey
 from pyinjective import PublicKey
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, repr=False)
 class Wallet:
   private_key: PrivateKey
   mnemonic: Optional[str] = None


### PR DESCRIPTION
# Testing

![Screenshot 2023-04-07 at 00 15 27](https://user-images.githubusercontent.com/126547568/230539896-8f10ff5e-f3af-47b0-ac87-018312acbc2b.png)
