### PR TITLE
fix: rename frontrunner-* to partner-*

### DIFF
--- a/docs/includes/_configuring.md
+++ b/docs/includes/_configuring.md
@@ -27,7 +27,7 @@ This is the base URL for Frontrunner-specific operations such as finding markets
 
 ### Environment Variables
 
-* `FRONTRUNNER_FRONTRUNNER_API_BASE_URL`
+* `FRONTRUNNER_PARTNER_API_BASE_URL`
 
 ### Default
 
@@ -39,7 +39,7 @@ To interact with the Frontrunner APIs, you will need a token to authenticate. Re
 
 ### Environment Variable
 
-* `FRONTRUNNER_FRONTRUNNER_API_AUTHN_TOKEN`
+* `FRONTRUNNER_PARTNER_API_AUTHN_TOKEN`
 
 ### Default
 

--- a/docs/includes/_quickstart.md
+++ b/docs/includes/_quickstart.md
@@ -10,7 +10,7 @@ pip install -y frontrunner-sdk
 
 Install the Frontrunner SDK using the following code.
 
-Contact [support@getfrontrunner.com][support] for a Frontrunner API Key. Keep this somewhere safe. When launching a Python REPL or running the scripts in this guide, make sure that API Key is set in the environment variable `FRONTRUNNER_FRONTRUNNER_API_AUTHN_TOKEN`.
+Contact [support@getfrontrunner.com][support] for a Frontrunner API Key. Keep this somewhere safe. When launching a Python REPL or running the scripts in this guide, make sure that API Key is set in the environment variable `FRONTRUNNER_PARTNER_API_AUTHN_TOKEN`.
 
 [support]: mailto:support@getfrontrunner.com
 

--- a/frontrunner_sdk/config/__init__.py
+++ b/frontrunner_sdk/config/__init__.py
@@ -17,7 +17,7 @@ DEFAULT: FrontrunnerConfig = ChainedFrontrunnerConfig([
   ),
 
   # frontrunner api
-  StaticFrontrunnerConfig(frontrunner_api_base_url="https://partner-api-staging.getfrontrunner.com/api/v1"),
+  StaticFrontrunnerConfig(partner_api_base_url="https://partner-api-staging.getfrontrunner.com/api/v1"),
 
   # injective k8s network
   ConditionalFrontrunnerConfig(

--- a/frontrunner_sdk/config/base.py
+++ b/frontrunner_sdk/config/base.py
@@ -18,11 +18,11 @@ class FrontrunnerConfig:
     return None
 
   @property
-  def frontrunner_api_base_url(self) -> Optional[str]:
+  def partner_api_base_url(self) -> Optional[str]:
     return None
 
   @property
-  def frontrunner_api_authn_token(self) -> Optional[str]:
+  def partner_api_authn_token(self) -> Optional[str]:
     return None
 
   @property

--- a/frontrunner_sdk/config/chained.py
+++ b/frontrunner_sdk/config/chained.py
@@ -32,12 +32,12 @@ class ChainedFrontrunnerConfig(FrontrunnerConfig):
     return self._find_next(lambda config: config.wallet_private_key_hex)
 
   @property
-  def frontrunner_api_base_url(self) -> Optional[str]:
-    return self._find_next(lambda config: config.frontrunner_api_base_url)
+  def partner_api_base_url(self) -> Optional[str]:
+    return self._find_next(lambda config: config.partner_api_base_url)
 
   @property
-  def frontrunner_api_authn_token(self) -> Optional[str]:
-    return self._find_next(lambda config: config.frontrunner_api_authn_token)
+  def partner_api_authn_token(self) -> Optional[str]:
+    return self._find_next(lambda config: config.partner_api_authn_token)
 
   @property
   def injective_network(self) -> Optional[NetworkEnvironment]:

--- a/frontrunner_sdk/config/conditional.py
+++ b/frontrunner_sdk/config/conditional.py
@@ -20,12 +20,12 @@ class ConditionalFrontrunnerConfig(FrontrunnerConfig):
     return self.config.wallet_private_key_hex if self.condition() else None
 
   @property
-  def frontrunner_api_base_url(self) -> Optional[str]:
-    return self.config.frontrunner_api_base_url if self.condition() else None
+  def partner_api_base_url(self) -> Optional[str]:
+    return self.config.partner_api_base_url if self.condition() else None
 
   @property
-  def frontrunner_api_authn_token(self) -> Optional[str]:
-    return self.config.frontrunner_api_authn_token if self.condition() else None
+  def partner_api_authn_token(self) -> Optional[str]:
+    return self.config.partner_api_authn_token if self.condition() else None
 
   @property
   def injective_network(self) -> Optional[NetworkEnvironment]:

--- a/frontrunner_sdk/config/environment_variable.py
+++ b/frontrunner_sdk/config/environment_variable.py
@@ -21,12 +21,12 @@ class EnvironmentVariableFrontrunnerConfig(FrontrunnerConfig):
     return self.vars.get("FRONTRUNNER_WALLET_PRIVATE_KEY_HEX", None)
 
   @property
-  def frontrunner_api_base_url(self) -> Optional[str]:
-    return self.vars.get("FRONTRUNNER_FRONTRUNNER_API_BASE_URL", None)
+  def partner_api_base_url(self) -> Optional[str]:
+    return self.vars.get("FRONTRUNNER_PARTNER_API_BASE_URL", None)
 
   @property
-  def frontrunner_api_authn_token(self) -> Optional[str]:
-    return self.vars.get("FRONTRUNNER_FRONTRUNNER_API_AUTHN_TOKEN", None)
+  def partner_api_authn_token(self) -> Optional[str]:
+    return self.vars.get("FRONTRUNNER_PARTNER_API_AUTHN_TOKEN", None)
 
   @property
   def injective_network(self) -> Optional[NetworkEnvironment]:

--- a/frontrunner_sdk/config/static.py
+++ b/frontrunner_sdk/config/static.py
@@ -9,8 +9,8 @@ from frontrunner_sdk.config.base import NetworkEnvironment
 class StaticFrontrunnerConfig(FrontrunnerConfig):
   wallet_mnemonic: Optional[str] = None
   wallet_private_key_hex: Optional[str] = None
-  frontrunner_api_base_url: Optional[str] = None
-  frontrunner_api_authn_token: Optional[str] = None
+  partner_api_base_url: Optional[str] = None
+  partner_api_authn_token: Optional[str] = None
   injective_network: Optional[NetworkEnvironment] = None
   injective_chain_id: Optional[str] = None
   injective_exchange_authority: Optional[str] = None

--- a/frontrunner_sdk/ioc.py
+++ b/frontrunner_sdk/ioc.py
@@ -63,12 +63,12 @@ class FrontrunnerIoC(SyncMixin):
 
     config = api.api_client.configuration
 
-    if self.config.frontrunner_api_base_url:
-      config.host = self.config.frontrunner_api_base_url
+    if self.config.partner_api_base_url:
+      config.host = self.config.partner_api_base_url
 
-    if self.config.frontrunner_api_authn_token:
+    if self.config.partner_api_authn_token:
       config.api_key = {
-        "Authorization": self.config.frontrunner_api_authn_token,
+        "Authorization": self.config.partner_api_authn_token,
       }
 
     return api

--- a/tests/commands/frontrunner/test_find_markets.py
+++ b/tests/commands/frontrunner/test_find_markets.py
@@ -21,7 +21,7 @@ class TestFindMarketsOperation(IsolatedAsyncioTestCase):
   def setUp(self) -> None:
     self.deps = MagicMock(spec=FrontrunnerIoC)
 
-  def setup_frontrunner_api(
+  def setup_partner_api(
     self,
     leagues: Optional[List[League]] = None,
     sport_events: Optional[List[SportEvent]] = None,
@@ -36,7 +36,7 @@ class TestFindMarketsOperation(IsolatedAsyncioTestCase):
     self.deps.openapi_frontrunner_api.get_markets = AsyncMock(return_value=markets or [])
 
   async def test_find_markets_everything(self):
-    self.setup_frontrunner_api(
+    self.setup_partner_api(
       leagues=[League(id="league", name="league")],
       sport_events=[SportEvent(id="sport-event", league_id="league", name="sport-event")],
       sport_entities=[SportEntity(id="sport-entity", league_id="league", name="sport-entity")],
@@ -68,7 +68,7 @@ class TestFindMarketsOperation(IsolatedAsyncioTestCase):
     self.assertEqual(res.market_ids, ["injective-market"])
 
   async def test_find_markets_short_circuit(self):
-    self.setup_frontrunner_api(leagues=[])
+    self.setup_partner_api(leagues=[])
 
     req = FindMarketsRequest(
       sports=[],

--- a/tests/test_ioc.py
+++ b/tests/test_ioc.py
@@ -57,7 +57,7 @@ class TestFrontrunnerIoC(IsolatedAsyncioTestCase):
     _initialize_wallet.assert_awaited_once()
 
   def test_openapi_frontrunner_api(self):
-    ioc = self.ioc_for(frontrunner_api_base_url="http://frontrunner.example")
+    ioc = self.ioc_for(partner_api_base_url="http://frontrunner.example")
 
     self.assertIsInstance(ioc.openapi_frontrunner_api, FrontrunnerApi)
 


### PR DESCRIPTION
The env var `FRONTRUNNER_FRONTRUNNER_*` looks awkward and like a mistake, so we're renaming it.