### PR TITLE
chore: prohibit python 3.11

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10"]
     permissions:
       contents: read
       checks: write

--- a/BUILD
+++ b/BUILD
@@ -36,7 +36,7 @@ python_distribution(
         author="Frontrunner",
         author_email="support@getfrontrunner.com",
         url="https://github.com/GetFrontrunner/frontrunner-sdk",
-        python_requires=">=3.8,<4",
+        python_requires=">=3.8,<=3.10",
         classifiers=[
             # https://pypi.org/classifiers/
             "Development Status :: 3 - Alpha",
@@ -48,7 +48,6 @@ python_distribution(
             "Programming Language :: Python :: 3.8",
             "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
         ],
     ),
 )

--- a/pants.toml
+++ b/pants.toml
@@ -28,7 +28,7 @@ pants_ignore = [
 ]
 
 [python]
-interpreter_constraints = ["CPython>=3.8.*,<=3.10"]
+interpreter_constraints = ["CPython>=3.8.*,<=3.10.*"]
 
 [test]
 report = true

--- a/pants.toml
+++ b/pants.toml
@@ -28,7 +28,7 @@ pants_ignore = [
 ]
 
 [python]
-interpreter_constraints = ["CPython>=3.8.*,<4"]
+interpreter_constraints = ["CPython>=3.8.*,<=3.10"]
 
 [test]
 report = true

--- a/pants.toml
+++ b/pants.toml
@@ -28,7 +28,7 @@ pants_ignore = [
 ]
 
 [python]
-interpreter_constraints = ["CPython>=3.8.*,<=3.10.*"]
+interpreter_constraints = ["CPython>=3.8,<3.11"]
 
 [test]
 report = true


### PR DESCRIPTION
There's an outstanding issue with injective-py that stops 3.11 from installing correctly. Once that's addressed, we can remove this constraint.

ref: https://github.com/InjectiveLabs/sdk-python/issues/173