### PR TITLE
docs: use USDT market for quickstart so that orders succeed

### DIFF
--- a/docs/includes/_quickstart.md
+++ b/docs/includes/_quickstart.md
@@ -136,5 +136,5 @@ get_orders = sdk.injective.get_orders(mine=True, execution_types=["limit"])
 
 print("orders:")
 for order in get_orders.orders:
-  print(f"{order.order_hash}: {order.quantity} @ {order.price}")
+  print(f"{order.order_hash}: {order.quantity} @ ${int(order.price) / USDC_SCALE_FACTOR}")
 ```

--- a/docs/includes/_quickstart.md
+++ b/docs/includes/_quickstart.md
@@ -103,7 +103,7 @@ We'll call `get_order_books`, passing in the Injective market id, to get the cur
 from frontrunner_sdk.models import Order
 
 highest_buy = 0.01
-injective_id = "0xb3a7e524c2ba5ec1eb44bf6780881d671992537eeab1428b8a44b205ceb3c304"
+injective_id = "0xd03091c74e4e76878c2afbeb470b1c825677014afdaa3d315fa534884d2d90e1"
 
 create_orders = sdk.injective.create_orders([
     Order.buy_long(injective_id, 10, highest_buy + 0.01),


### PR DESCRIPTION
using a generated wallet that was funded by the faucet with USDT:
```python
import asyncio

from frontrunner_sdk import FrontrunnerSDKAsync
from frontrunner_sdk.models import Order


async def maina():
    sdk = FrontrunnerSDKAsync()
    highest_buy = 0.01
    injective_id = "0xd03091c74e4e76878c2afbeb470b1c825677014afdaa3d315fa534884d2d90e1"

    create_orders = await sdk.injective.create_orders([
        Order.buy_long(injective_id, 10, highest_buy + 0.01),
        Order.buy_long(injective_id, 5, highest_buy + 0.02),
    ])

    print(f"""
    Transaction: {create_orders.transaction}

    You can view your transaction at:

      https://testnet.explorer.injective.network/transaction/{create_orders.transaction}

    """)
    get_orders = await sdk.injective.get_orders(mine=True, execution_types=["limit"])

    print("orders:")
    for order in get_orders.orders:
        print(f"{order.order_hash}: {order.quantity} @ {order.price}")


def main():
    asyncio.run(maina())


if __name__ == "__main__":
    main()
```
output:
```
INFO:chain session cookie loaded from disk:
INFO:Loaded market metadata for:Frontrunner
INFO:Loaded market metadata for:Frontrunner
INFO:CreateOrdersOperation with CreateOrdersRequest(orders=[Order(direction='buy', side='long', market_id='0xd03091c74e4e76878c2afbeb470b1c825677014afdaa3d315fa534884d2d90e1', quantity=10, price=0.02), Order(direction='buy', side='long', market_id='0xd03091c74e4e76878c2afbeb470b1c825677014afdaa3d315fa534884d2d90e1', quantity=5, price=0.03)])

    Transaction: E20236FD2FE0AEF8BE04A6543BDE9CC7FE0AE10FDADEC3389C6BC606DDD8F686

    You can view your transaction at:

      https://testnet.explorer.injective.network/transaction/E20236FD2FE0AEF8BE04A6543BDE9CC7FE0AE10FDADEC3389C6BC606DDD8F686
INFO:GetOrdersOperation with GetOrdersRequest(mine=True, market_ids=None, subaccount_id=None, direction=None, is_conditional=None, order_types=None, state=None, execution_types=['limit'], start_time=None, end_time=None)
orders:
0x52497272ad33e81a8ed5721456f34224f971ca94045b3c6238f7e73d8574a1de: 5 @ 0.03
0x63fe46cd747f5863442a2f685fd2cb64ee00537bacb1da2445a9deaf2606fb19: 10 @ 0.02
```