### PR TITLE
chore: remove obsolete pants ignore config

### DIFF
--- a/pants.toml
+++ b/pants.toml
@@ -22,9 +22,6 @@ backend_packages = [
 pants_ignore = [
   # default
   ".*/", "/dist/", "__pycache__",
-
-  # ignore existing code
-  "chain", "data", "examples", "strategy", "utils",
 ]
 
 [python]


### PR DESCRIPTION
These directories were emptied prior to release.