### PR TITLE
fix: short circuit cancel all orders when no orders

### DIFF
--- a/docs/includes/operations/injective/_cancel_all_orders.md
+++ b/docs/includes/operations/injective/_cancel_all_orders.md
@@ -15,8 +15,12 @@ There are no parameters for this operation.
 
 ```python
 print("transaction:", response.transaction)
+print("orders:")
+for order in response.orders:
+  print(f"\tmarket: {order.market_id[:12]}... price: {order.price} quantity: {order.quantity}")
 ```
 
 | Name | Type | Description |
 | - | - | - |
-| `transaction` | `str` | Transaction ID of the order cancellation |
+| `orders` | `Iterable[DerivativeLimitOrder]` | Cancelled orders |
+| `transaction` | `Optional[str]` | Transaction ID of the order cancellation |

--- a/tests/facades/test_injective.py
+++ b/tests/facades/test_injective.py
@@ -86,7 +86,7 @@ class TestInjectiveFacadeAsync(IsolatedAsyncioTestCase):
     CancelAllOrdersOperation,
     "execute",
     new_callable=AsyncMock,
-    return_value=CancelAllOrdersResponse(transaction="<hash>"),
+    return_value=CancelAllOrdersResponse(transaction="<hash>", orders=[]),
   )
   async def test_cancel_all_orders(self, _execute: AsyncMock):
     await self.facade.cancel_all_orders()


### PR DESCRIPTION
Sending over an empty batch update to injective results in an error, which doesn't make much sense.

This returns early so we don't actually send the batch update.