### PR TITLE
BREAKING CHANGE: upgrade Injective SDK version for new 'FRCOIN' currency; only support Python 3.9+

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -44,7 +44,7 @@ python_distribution(
         author="Frontrunner",
         author_email="support@getfrontrunner.com",
         url="https://github.com/GetFrontrunner/frontrunner-sdk",
-        python_requires=">=3.8,<3.11",
+        python_requires=">=3.9,<3.11",
         classifiers=[
             # https://pypi.org/classifiers/
             "Development Status :: 3 - Alpha",

--- a/docs/includes/_quickstart.md
+++ b/docs/includes/_quickstart.md
@@ -86,23 +86,23 @@ Then, we'll pick one market to place bets on, and print some info about it.
 response = sdk.injective.get_order_books([market.injective_id])
 order_book = response.order_books[market.injective_id]
 
-# Frontrunner markets are in USDC while on Injective, USDC has 6 decimals.
-# 1,000,000 from Injective is $1 USDC.
-USDC_SCALE_FACTOR = 10 ** 6
+# Frontrunner testnet markets are in FRCOIN and on Injective, FRCOIN has 6 decimals.
+# 1,000,000 from Injective is $1 FRCOIN.
+FRCOIN_SCALE_FACTOR = 10 ** 6
 
 # print order book buys
 print("buys:")
 for buy in order_book.buys:
-  print(f"  {buy.quantity} @ ${int(buy.price) / USDC_SCALE_FACTOR}")
+  print(f"  {buy.quantity} @ ${int(buy.price) / FRCOIN_SCALE_FACTOR}")
 
 # print order book sells
 print("sells:")
 for sell in order_book.sells:
-  print(f"  {sell.quantity} @ ${int(sell.price) / USDC_SCALE_FACTOR}")
+  print(f"  {sell.quantity} @ ${int(sell.price) / FRCOIN_SCALE_FACTOR}")
 
 # find the highest buy and lowest sell
-buy_prices = [int(order.price) / USDC_SCALE_FACTOR for order in order_book.buys]
-sell_prices = [int(order.price) / USDC_SCALE_FACTOR for order in order_book.sells]
+buy_prices = [int(order.price) / FRCOIN_SCALE_FACTOR for order in order_book.buys]
+sell_prices = [int(order.price) / FRCOIN_SCALE_FACTOR for order in order_book.sells]
 highest_buy, lowest_sell = max(buy_prices), min(sell_prices)
 print(f"bid-ask spread: [${highest_buy}, ${lowest_sell}]")
 ```
@@ -165,7 +165,7 @@ To place the orders, we'll call `create_orders`. We'll place...
 
 Note that we use a hard-coded market ID here that points to a testnet USDT market that can be traded in with Injective Faucet funds.
 
-Contact [support@getfrontrunner.com][support] to request testnet USDC to trade in real Frontrunner markets.
+Contact [support@getfrontrunner.com][support] to request testnet FRCOIN to trade in real Frontrunner markets.
 
 ## Retrieving Your Orders
 
@@ -174,7 +174,7 @@ get_orders = sdk.injective.get_orders(mine=True, execution_types=["limit"])
 
 print("orders:")
 for order_history in get_orders.orders:
-  print(f"  {order_history.order_type} {order_history.order.order_hash}: {order_history.order.quantity} @ ${int(order_history.order.price) / USDC_SCALE_FACTOR}")
+  print(f"  {order_history.order_type} {order_history.order.order_hash}: {order_history.order.quantity} @ ${int(order_history.order.price) / FRCOIN_SCALE_FACTOR}")
 ```
 
 > **Output**

--- a/docs/includes/utilities/_currency.md
+++ b/docs/includes/utilities/_currency.md
@@ -1,6 +1,6 @@
 ## Currency
 
-Injective operates on raw coin quantities instead of decimal values. For example, 8 USDC would be represented as `"8000000"`. This is because USDC's denomination is to 6 decimal places, and 8 shifted by 6 decimal places is 8,000,000.
+Injective operates on raw coin quantities instead of decimal values. For example, 8 FRCOIN (as well as USDC and USDT) would be represented as `"8000000"`. This is because FRCOIN's denomination is to 6 decimal places, and 8 shifted by 6 decimal places is 8,000,000.
 
 Each denomination has its own fractional resolution, and all are mapped in Injective's SDK. See:
 
@@ -21,7 +21,7 @@ Factory for `Currency`, given the Injective-side quantity and denomination.
 #### Example
 
 ```python
-currency = sdk.utilities.currency_from_quantity(420_690_000, "USDC")
+currency = sdk.utilities.currency_from_quantity(420_690_000, "FRCOIN")
 print(
   "currency:",
   "[", currency.value, currency.denom.name, "]",
@@ -49,7 +49,7 @@ Factory for `Currency`, given the human-readable quantity and denomination.
 #### Example
 
 ```python
-currency = sdk.utilities.currency_from_value(420.69, "USDC")
+currency = sdk.utilities.currency_from_value(420.69, "FRCOIN")
 print(
   "currency:",
   "[", currency.value, currency.denom.name, "]",

--- a/pants.toml
+++ b/pants.toml
@@ -25,7 +25,7 @@ pants_ignore = [
 ]
 
 [python]
-interpreter_constraints = ["CPython>=3.8,<3.11"]
+interpreter_constraints = ["CPython>=3.9,<3.11"]
 
 [test]
 report = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-injective-py==0.6.*
+injective-py==0.7.*
 aiohttp~=3.8.4
 
 # dependency of dependency that we need to reference

--- a/tests/config/test_configs.py
+++ b/tests/config/test_configs.py
@@ -72,7 +72,7 @@ class TestFrontrunnerConfig(TestCase):
     self.assertEqual(True, DEFAULT.injective_insecure)
     self.assertEqual("sentry0.injective.network:9910", DEFAULT.injective_exchange_authority)
     self.assertEqual("sentry0.injective.network:9900", DEFAULT.injective_grpc_authority)
-    self.assertEqual("https://lcd.injective.network", DEFAULT.injective_lcd_base_url)
+    self.assertEqual("http://sentry0.injective.network:10337", DEFAULT.injective_lcd_base_url)
     self.assertEqual("ws://sentry0.injective.network:26657/websocket", DEFAULT.injective_rpc_base_url)
     self.assertEqual("sentry0.injective.network:9911", DEFAULT.injective_explorer_authority)
     self.assertEqual("https://partner-api-mainnet.getfrontrunner.com/api/v1", DEFAULT.partner_api_base_url)


### PR DESCRIPTION
* upgrades Injective SDK version (required to include new `FRCOIN` currency: https://github.com/InjectiveLabs/sdk-python/blob/v0.7.0.3/pyinjective/denoms_testnet.ini#L222
* Update docs to reference `FRCOIN` instead of testnet `USDC`, which won't be used after 8/4
* Fix config test

# Testing
```python
async def maina():
    sdk = FrontrunnerSDKAsync()
    print(f"Running with wallet {(await sdk.wallet()).injective_address}")

    injective_market_id = "0xc331d84b090208b1d460f9927e51a1b266e7dfe9e1df9250c6fa20780e8b4271"
    response = await sdk.frontrunner.get_markets(injective_id=injective_market_id)
    market = response.markets[0]

    # View an Order Book
    # get the order book for this market
    response = await sdk.injective.get_order_books([market.injective_id])
    order_book = response.order_books[market.injective_id]

    # Frontrunner markets are in USDC while on Injective, USDC has 6 decimals.
    # 1,000,000 from Injective is $1 USDC.
    FRCOIN_SCALE_FACTOR = 10 ** 6
    print("buys:")
    for buy in order_book.buys:
        print(f"  {buy.quantity} @ ${int(buy.price) / FRCOIN_SCALE_FACTOR}")
    print("sells:")
    for sell in order_book.sells:
        print(f"  {sell.quantity} @ ${int(sell.price) / FRCOIN_SCALE_FACTOR}")

    # find the highest buy and lowest sell
    buy_prices = [int(order.price) / FRCOIN_SCALE_FACTOR for order in order_book.buys]
    sell_prices = [int(order.price) / FRCOIN_SCALE_FACTOR for order in order_book.sells]
    highest_buy, lowest_sell = max(buy_prices), min(sell_prices)
    print(f"bid-ask spread: [${highest_buy}, ${lowest_sell}]")

    highest_buy = 0.01
    create_orders = await sdk.injective.create_orders([
        Order.buy_long(injective_market_id, 1, highest_buy + 0.01),
    ])
    print(f"""
    Transaction: {create_orders.transaction}

    You can view your transaction at:

      https://testnet.explorer.injective.network/transaction/{create_orders.transaction}
    """)

    get_orders = await sdk.injective.get_orders(mine=True, market_ids=[injective_market_id])
    print("orders:")
    for order_history in get_orders.orders:
        print(f"{order_history.order.order_hash}: {order_history.order.quantity} @ ${int(float(order_history.order.price)) / FRCOIN_SCALE_FACTOR}")
```
output:
```
Running with wallet inj14w0zfp47jqpgjst87vxg5ydgvtevfdm38338xp
buys:
  4762 @ $0.42
  7317 @ $0.41
  12500 @ $0.4
  1 @ $0.02
sells:
  4545 @ $0.44
  6667 @ $0.45
  10870 @ $0.46
bid-ask spread: [$0.42, $0.44]
orders:
0x4a3f11b8b375a69d70913caa367e619647a98299fd6f5854342ca66ccc62d69f: 1 @ $0.02
```

Also tested currency retrieval and `FRCOIN` loaded successfully
