### PR TITLE
chore: remove python 3.8 from tests matrix

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.9", "3.10"]
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
Python 3.8 support was removed in #91 