### PR TITLE
feat: subaccount transfer operations

### DIFF
--- a/docs/includes/_subaccount_management.md
+++ b/docs/includes/_subaccount_management.md
@@ -19,11 +19,24 @@ Subaccount balances are associated with each subaccount (e.g. `0xb4efdbe3240d3d2
 ## Transferring Funds
 These are the operations involved in transferring funds between accounts or subaccounts:
 
-| Operation                  | Usage                                                                                                                                                              | Notes                                                                                        |
-|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| `fund_external_subaccount` | Send funds to a subaccount that is NOT owned by the SDK wallet.                                                                                                    | Cannot fund subaccount 0.                                                                    |
-| `fund_subaccount`          | Send funds from the main bank balance to a subaccount that IS owned by the SDK wallet. Or, send funds between subaccounts that ARE BOTH owned by the SDK wallet.   | Cannot fund subaccount 0. Funding from source subaccount 0 sends from the main bank balance. |
-| `withdraw_from_subaccount` | Withdraw funds from a subaccount that IS owned by the SDK wallet to the main bank balance.                                                                         | Cannot withdraw from subaccount 0.                                                           |
+| Operation                  | Usage                                                                                                                                                             | Notes                                                                                        |
+|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `fund_external_subaccount` | Send funds to a subaccount that is NOT owned by the SDK wallet.                                                                                                   | Cannot fund subaccount 0.                                                                    |
+| `fund_subaccount`          | Send funds from the main bank balance to a subaccount that IS owned by the SDK wallet. Or send funds between subaccounts that ARE BOTH owned by the SDK wallet.   | Cannot fund subaccount 0. Funding from source subaccount 0 sends from the main bank balance. |
+| `withdraw_from_subaccount` | Withdraw funds from a subaccount that IS owned by the SDK wallet to the main bank balance.                                                                        | Cannot withdraw from subaccount 0.                                                           |
+
+Where operations involve subaccounts owned by the SDK wallet, either a `Subaccount` object or an integer `index` can be provided for convenience.  
+A `Subaccount` object can be created in a few different ways:
+
+```python
+from frontrunner_sdk.models import Subaccount
+
+Subaccount.from_subaccount_id("0xb4efdbe3240d3d2a1bc6be8a1f717944e734a0dd000000000000000000000001")
+Subaccount.from_wallet_and_index(await sdk.wallet(), 1)
+Subaccount.from_injective_address_and_index("inj1knhahceyp57j5x7xh69p7utegnnnfgxavmahjr", 1)
+Subaccount.from_ethereum_address_and_index("0xb4efdbe3240d3d2a1bc6be8a1f717944e734a0dd", 1)
+```
+
 
 ## Sample Code: Market Making
 A simple setup to create liquidity on both sides of a Frontrunner market involves using two non-default 
@@ -99,10 +112,10 @@ async def main():
   short_subaccount = wallet.subaccount_address(short_subaccount_index)
   print(f"Running with wallet {wallet.injective_address}. {long_subaccount=}, {short_subaccount=}")
 
-  response = await sdk.injective.fund_subaccount(1000, "FRCOIN", subaccount_index=long_subaccount_index)
+  response = await sdk.injective.fund_subaccount(1000, "FRCOIN", destination_subaccount_index=long_subaccount_index)
   print(f"View deposit transaction to long side subaccount: https://testnet.explorer.injective.network/transaction/{response.transaction}")
 
-  response = await sdk.injective.fund_subaccount(1000, "FRCOIN", subaccount_index=short_subaccount_index)
+  response = await sdk.injective.fund_subaccount(1000, "FRCOIN", destination_subaccount_index=short_subaccount_index)
   print(f"View deposit transaction to short side subaccount: https://testnet.explorer.injective.network/transaction/{response.transaction}")
 
   probability = 0.68

--- a/docs/includes/_subaccount_management.md
+++ b/docs/includes/_subaccount_management.md
@@ -19,6 +19,11 @@ Subaccount balances are associated with each subaccount (e.g. `0xb4efdbe3240d3d2
 ## Transferring Funds
 These are the operations involved in transferring funds between accounts or subaccounts:
 
+| Operation                  | Usage                                                                                                                                                              | Notes                                                                                        |
+|----------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
+| `fund_external_subaccount` | Send funds to a subaccount that is NOT owned by the SDK wallet.                                                                                                    | Cannot fund subaccount 0.                                                                    |
+| `fund_subaccount`          | Send funds from the main bank balance to a subaccount that IS owned by the SDK wallet. Or, send funds between subaccounts that ARE BOTH owned by the SDK wallet.   | Cannot fund subaccount 0. Funding from source subaccount 0 sends from the main bank balance. |
+| `withdraw_from_subaccount` | Withdraw funds from a subaccount that IS owned by the SDK wallet to the main bank balance.                                                                         | Cannot withdraw from subaccount 0.                                                           |
 
 ## Sample Code: Market Making
 A simple setup to create liquidity on both sides of a Frontrunner market involves using two non-default 

--- a/docs/includes/_subaccount_management.md
+++ b/docs/includes/_subaccount_management.md
@@ -7,14 +7,20 @@ so they can be used to isolate positions or margin or to run multiple strategies
 All orders in Injective markets are from a subaccount (often the default subaccount).
 
 Subaccounts are 0-indexed, and the default subaccount, subaccount 0, has a special 
-property: trading from the default subaccount draws funds from the main bank balance. 
+property: trading from the default subaccount draws funds from the **main bank balance**.
 Detailed information about this feature can be found [here](https://injective.notion.site/The-new-trading-logic-to-be-introduced-in-v1-10-8b422f7bec6c4cac96459d558e917b6d).
+The main bank balance is associated with the Injective address (e.g. `inj14w0zfp47jqpgjst87vxg5ydgvtevfdm38338xp`).
+Subaccount balances are associated with each subaccount (e.g. `0xb4efdbe3240d3d2a1bc6be8a1f717944e734a0dd000000000000000000000000`).
 
 ## Properties
 * Each subaccount can have a maximum of 20 open orders per market
 * A single subaccount cannot create orders for both the `long` and `short` sides in a binary options market
 
-## Sample Code
+## Transferring Funds
+These are the operations involved in transferring funds between accounts or subaccounts:
+
+
+## Sample Code: Market Making
 A simple setup to create liquidity on both sides of a Frontrunner market involves using two non-default 
 subaccounts, where one subaccount creates `long` orders and another creates `short` orders.
 

--- a/docs/includes/_subaccount_management.md
+++ b/docs/includes/_subaccount_management.md
@@ -29,10 +29,12 @@ Where operations involve subaccounts owned by the SDK wallet, either a `Subaccou
 A `Subaccount` object can be created in a few different ways:
 
 ```python
-from frontrunner_sdk.models import Subaccount
+from frontrunner_sdk.models import Subaccount, Wallet
+
+wallet = Wallet._new()
 
 Subaccount.from_subaccount_id("0xb4efdbe3240d3d2a1bc6be8a1f717944e734a0dd000000000000000000000001")
-Subaccount.from_wallet_and_index(await sdk.wallet(), 1)
+wallet.subaccount(1)
 Subaccount.from_injective_address_and_index("inj1knhahceyp57j5x7xh69p7utegnnnfgxavmahjr", 1)
 Subaccount.from_ethereum_address_and_index("0xb4efdbe3240d3d2a1bc6be8a1f717944e734a0dd", 1)
 ```

--- a/docs/includes/operations/injective/_fund_external_subaccount.md
+++ b/docs/includes/operations/injective/_fund_external_subaccount.md
@@ -1,0 +1,27 @@
+## Injective: Fund External Subaccount
+
+Send funds to a subaccount that is NOT owned by the SDK wallet.
+
+### Parameters
+
+```python
+external_subaccount = Subaccount.from_injective_address_and_index("inj1fjlfjy5adns4msjqch3vqjhesmwjnu9ep045wz", 1)
+response = await sdk.injective.fund_external_subaccount(10, "FRCOIN", external_subaccount)
+```
+
+| Name | Type | Req? | Description |
+| - | - | - | - |
+| `amount` | `int` | ✓ | Amount to send |
+| `denom` | `str` | ✓ | Denom identifier |
+| `destination_subaccount` | `Subaccount` | ✓ | Subaccount to send to; cannot be subaccount 0 |
+| `source_subaccount_index` | `Optional[int]` | ◯ `None` | If provided, send from SDK wallet's subaccount with this index |
+
+### Response
+
+```python
+print("transaction:", response.transaction)
+```
+
+| Name | Type | Description |
+| - | - | - |
+| `transaction` | `str` | Injective Transaction ID |

--- a/docs/includes/operations/injective/_fund_subaccount.md
+++ b/docs/includes/operations/injective/_fund_subaccount.md
@@ -7,7 +7,7 @@ Send funds from the main bank balance to a subaccount that IS owned by the SDK w
 ```python
 destination_subaccount_index = 2
 wallet = await sdk.wallet()
-destination_subaccount = Subaccount.from_wallet_and_index(wallet, destination_subaccount_index)
+destination_subaccount = wallet.subaccount(destination_subaccount_index)
 
 # Equivalent methods of transferring from main bank balance to a subaccount
 response = await sdk.injective.fund_subaccount(5, "FRCOIN", destination_subaccount_index=1)

--- a/docs/includes/operations/injective/_fund_subaccount.md
+++ b/docs/includes/operations/injective/_fund_subaccount.md
@@ -1,0 +1,39 @@
+## Injective: Fund Subaccount
+
+Send funds to a subaccount that IS owned by the SDK wallet.
+
+### Parameters
+
+```python
+destination_subaccount_index = 2
+wallet = await sdk.wallet()
+destination_subaccount = Subaccount.from_wallet_and_index(wallet, destination_subaccount_index)
+
+# Equivalent methods of transferring from main bank balance to a subaccount
+response = await sdk.injective.fund_subaccount(5, "FRCOIN", destination_subaccount_index=1)
+response = await sdk.injective.fund_subaccount(5, "FRCOIN", destination_subaccount=destination_subaccount)
+
+# Equivalent methods of transferring between subaccounts
+response = await sdk.injective.fund_subaccount(5, "FRCOIN", source_subaccount_index=1, destination_subaccount_index=destination_subaccount_index)
+response = await sdk.injective.fund_subaccount(5, "FRCOIN", source_subaccount_index=1, destination_subaccount=destination_subaccount)
+```
+
+| Name | Type | Req? | Description |
+| - | - | - | - |
+| `amount` | `int` | ✓ | Amount to send |
+| `denom` | `str` | ✓ | Denom identifier |
+| `destination_subaccount` | `Optional[Subaccount]` | ◯ `None` | Subaccount to send to; cannot be subaccount 0. |
+| `destination_subaccount_index` | `Optional[int]` | ◯ `None` | Subaccount to send to; cannot be subaccount 0 |
+| `source_subaccount_index` | `Optional[int]` | ◯ `None` | If provided, send from SDK wallet's subaccount with this index |
+
+`destination_subaccount` and `destination_subaccount_index` are mutually exclusive, and at least one must be specified.
+
+### Response
+
+```python
+print("transaction:", response.transaction)
+```
+
+| Name | Type | Description |
+| - | - | - |
+| `transaction` | `str` | Injective Transaction ID |

--- a/docs/includes/operations/injective/_fund_subaccount.md
+++ b/docs/includes/operations/injective/_fund_subaccount.md
@@ -1,6 +1,6 @@
 ## Injective: Fund Subaccount
 
-Send funds to a subaccount that IS owned by the SDK wallet.
+Send funds from the main bank balance to a subaccount that IS owned by the SDK wallet. Or send funds between subaccounts that ARE BOTH owned by the SDK wallet.
 
 ### Parameters
 

--- a/docs/includes/operations/injective/_withdraw_from_subaccount.md
+++ b/docs/includes/operations/injective/_withdraw_from_subaccount.md
@@ -1,0 +1,25 @@
+## Injective: Withdraw from Subaccount
+
+Withdraw funds from a subaccount that IS owned by the SDK wallet to the main bank balance.
+
+### Parameters
+
+```python
+response = await sdk.injective.withdraw_from_subaccount(10, "FRCOIN", subaccount_index=1)
+```
+
+| Name | Type | Req? | Description |
+| - | - | - | - |
+| `amount` | `int` | ✓ | Amount to send |
+| `denom` | `str` | ✓ | Denom identifier |
+| `subaccount_index` | `int` | ✓ | Withdraw from SDK wallet's subaccount with this index |
+
+### Response
+
+```python
+print("transaction:", response.transaction)
+```
+
+| Name | Type | Description |
+| - | - | - |
+| `transaction` | `str` | Injective Transaction ID |

--- a/docs/index.html.md
+++ b/docs/index.html.md
@@ -26,6 +26,8 @@ includes:
   - operations/injective/cancel_orders
   - operations/injective/create_orders
   - operations/injective/create_wallet
+  - operations/injective/fund_external_subaccount.md
+  - operations/injective/fund_subaccount.md
   - operations/injective/fund_wallet_from_faucet
   - operations/injective/get_account_portfolio
   - operations/injective/get_order_books
@@ -36,6 +38,7 @@ includes:
   - operations/injective/stream_orders
   - operations/injective/stream_positions
   - operations/injective/stream_trades
+  - operations/injective/withdraw_from_subaccount.md
   - utilities
   - utilities/currency
 

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -238,10 +238,10 @@ class InjectiveChain:
     return await self._execute_transaction(wallet, [message])
 
   @log_external_exceptions(__name__)
-  async def fund_external_subaccount(self, wallet: Wallet, subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str) -> TxResponse:
+  async def fund_external_subaccount(self, wallet: Wallet, source_subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str) -> TxResponse:
     message = self.composer.MsgExternalTransfer(
       wallet.injective_address,
-      source_subaccount_id=subaccount_id,
+      source_subaccount_id=source_subaccount_id,
       destination_subaccount_id=destination_subaccount_id,
       amount=amount,
       denom=denom,

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -227,10 +227,11 @@ class InjectiveChain:
     return await self._execute_transaction(wallet, [batch_message])
 
   @log_external_exceptions(__name__)
-  async def fund_subaccount(self, wallet: Wallet, subaccount_id: str, amount: int, denom: str) -> TxResponse:
-    message = self.composer.MsgDeposit(
+  async def fund_external_subaccount(self, wallet: Wallet, source_subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str) -> TxResponse:
+    message = self.composer.MsgExternalTransfer(
       wallet.injective_address,
-      subaccount_id=subaccount_id,
+      source_subaccount_id=source_subaccount_id,
+      destination_subaccount_id=destination_subaccount_id,
       amount=amount,
       denom=denom,
     )
@@ -238,11 +239,10 @@ class InjectiveChain:
     return await self._execute_transaction(wallet, [message])
 
   @log_external_exceptions(__name__)
-  async def fund_external_subaccount(self, wallet: Wallet, source_subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str) -> TxResponse:
-    message = self.composer.MsgExternalTransfer(
+  async def fund_subaccount(self, wallet: Wallet, subaccount_id: str, amount: int, denom: str) -> TxResponse:
+    message = self.composer.MsgDeposit(
       wallet.injective_address,
-      source_subaccount_id=source_subaccount_id,
-      destination_subaccount_id=destination_subaccount_id,
+      subaccount_id=subaccount_id,
       amount=amount,
       denom=denom,
     )

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -236,3 +236,15 @@ class InjectiveChain:
     )
 
     return await self._execute_transaction(wallet, [message])
+
+  @log_external_exceptions(__name__)
+  async def fund_external_subaccount(self, wallet: Wallet, subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str) -> TxResponse:
+    message = self.composer.MsgExternalTransfer(
+      wallet.injective_address,
+      source_subaccount_id=subaccount_id,
+      destination_subaccount_id=destination_subaccount_id,
+      amount=amount,
+      denom=denom,
+    )
+
+    return await self._execute_transaction(wallet, [message])

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -250,3 +250,14 @@ class InjectiveChain:
     )
 
     return await self._execute_transaction(wallet, [message])
+
+  @log_external_exceptions(__name__)
+  async def withdraw_from_subaccount(self, wallet: Wallet, subaccount_id: str, amount: int, denom: str) -> TxResponse:
+    message = self.composer.MsgWithdraw(
+      wallet.injective_address,
+      subaccount_id=subaccount_id,
+      amount=amount,
+      denom=denom,
+    )
+
+    return await self._execute_transaction(wallet, [message])

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -241,10 +241,24 @@ class InjectiveChain:
     return await self._execute_transaction(wallet, [message])
 
   @log_external_exceptions(__name__)
-  async def fund_subaccount(self, wallet: Wallet, subaccount_id: str, amount: int, denom: str) -> TxResponse:
+  async def fund_subaccount_from_bank(self, wallet: Wallet, subaccount_id: str, amount: int, denom: str) -> TxResponse:
     message = self.composer.MsgDeposit(
       wallet.injective_address,
       subaccount_id=subaccount_id,
+      amount=amount,
+      denom=denom,
+    )
+
+    return await self._execute_transaction(wallet, [message])
+
+  @log_external_exceptions(__name__)
+  async def fund_subaccount_from_subaccount(
+    self, wallet: Wallet, source_subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str
+  ) -> TxResponse:
+    message = self.composer.MsgSubaccountTransfer(
+      wallet.injective_address,
+      source_subaccount_id=source_subaccount_id,
+      destination_subaccount_id=destination_subaccount_id,
       amount=amount,
       denom=denom,
     )

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -227,7 +227,9 @@ class InjectiveChain:
     return await self._execute_transaction(wallet, [batch_message])
 
   @log_external_exceptions(__name__)
-  async def fund_external_subaccount(self, wallet: Wallet, source_subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str) -> TxResponse:
+  async def fund_external_subaccount(
+    self, wallet: Wallet, source_subaccount_id: str, destination_subaccount_id: str, amount: int, denom: str
+  ) -> TxResponse:
     message = self.composer.MsgExternalTransfer(
       wallet.injective_address,
       source_subaccount_id=source_subaccount_id,

--- a/frontrunner_sdk/commands/injective/cancel_orders.py
+++ b/frontrunner_sdk/commands/injective/cancel_orders.py
@@ -8,7 +8,6 @@ from frontrunner_sdk.commands.base import FrontrunnerOperation
 from frontrunner_sdk.exceptions import FrontrunnerArgumentException
 from frontrunner_sdk.ioc import FrontrunnerIoC
 from frontrunner_sdk.logging.log_operation import log_operation
-from frontrunner_sdk.models import Subaccount
 from frontrunner_sdk.models.cancel_order import CancelOrder
 
 
@@ -34,7 +33,7 @@ class CancelAllOrdersOperation(FrontrunnerOperation[CancelAllOrdersRequest, Canc
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> CancelAllOrdersResponse:
     wallet = await deps.wallet()
-    subaccount = Subaccount.from_wallet_and_index(wallet, self.request.subaccount_index)
+    subaccount = wallet.subaccount(self.request.subaccount_index)
 
     open_orders = await deps.injective_chain.get_all_open_orders(subaccount)
 

--- a/frontrunner_sdk/commands/injective/fund_external_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_external_subaccount.py
@@ -35,7 +35,7 @@ class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccoun
     # Use fund_subaccount (MsgDeposit) to send from bank balance shared with subaccount 0 because
     # fund_external_subaccount (MsgExternalTransfer) doesn't work from subaccount 0
     if self.request.source_subaccount_index == 0:
-      response = await deps.injective_chain.fund_subaccount(
+      response = await deps.injective_chain.fund_subaccount_from_bank(
         await deps.wallet(), destination_subaccount.subaccount_id, self.request.amount, self.request.denom
       )
     else:

--- a/frontrunner_sdk/commands/injective/fund_external_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_external_subaccount.py
@@ -19,7 +19,8 @@ class FundExternalSubaccountResponse:
   transaction: str
 
 
-class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccountRequest, FundExternalSubaccountResponse]):
+class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccountRequest,
+                                                           FundExternalSubaccountResponse]):
 
   def validate(self, deps: FrontrunnerIoC) -> None:
     pass
@@ -29,10 +30,7 @@ class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccoun
 
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> FundExternalSubaccountResponse:
-    source_subaccount = Subaccount.from_wallet_and_index(
-      await deps.wallet(),
-      self.request.source_subaccount_index
-    )
+    source_subaccount = Subaccount.from_wallet_and_index(await deps.wallet(), self.request.source_subaccount_index)
     destination_subaccount = self.request.destination_subaccount
     # Use fund_subaccount (MsgDeposit) to send from bank balance shared with subaccount 0 because
     # fund_external_subaccount (MsgExternalTransfer) doesn't work from subaccount 0
@@ -42,7 +40,8 @@ class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccoun
       )
     else:
       response = await deps.injective_chain.fund_external_subaccount(
-        await deps.wallet(), source_subaccount.subaccount_id, destination_subaccount.subaccount_id, self.request.amount, self.request.denom
+        await deps.wallet(), source_subaccount.subaccount_id, destination_subaccount.subaccount_id, self.request.amount,
+        self.request.denom
       )
 
     return FundExternalSubaccountResponse(transaction=response.txhash)

--- a/frontrunner_sdk/commands/injective/fund_external_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_external_subaccount.py
@@ -32,7 +32,7 @@ class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccoun
   async def execute(self, deps: FrontrunnerIoC) -> FundExternalSubaccountResponse:
     source_subaccount = Subaccount.from_wallet_and_index(await deps.wallet(), self.request.source_subaccount_index)
     destination_subaccount = self.request.destination_subaccount
-    # Use fund_subaccount (MsgDeposit) to send from bank balance shared with subaccount 0 because
+    # Use fund_subaccount_from_bank (MsgDeposit) to send from bank balance shared with subaccount 0 because
     # fund_external_subaccount (MsgExternalTransfer) doesn't work from subaccount 0
     if self.request.source_subaccount_index == 0:
       response = await deps.injective_chain.fund_subaccount_from_bank(

--- a/frontrunner_sdk/commands/injective/fund_external_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_external_subaccount.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from frontrunner_sdk.commands.base import FrontrunnerOperation
+from frontrunner_sdk.exceptions import FrontrunnerArgumentException
+from frontrunner_sdk.helpers.validation import validate_mutually_exclusive
+from frontrunner_sdk.ioc import FrontrunnerIoC
+from frontrunner_sdk.logging.log_operation import log_operation
+from frontrunner_sdk.models import Subaccount
+
+
+@dataclass
+class FundExternalSubaccountRequest:
+  amount: int
+  denom: str
+  source_subaccount_index
+  destination_subaccount: Subaccount
+
+
+@dataclass
+class FundExternalSubaccountResponse:
+  transaction: str
+
+
+class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccountRequest, FundExternalSubaccountResponse]):
+
+  def __init__(self, request: FundExternalSubaccountRequest):
+    super().__init__(request)
+
+  @log_operation(__name__)
+  async def execute(self, deps: FrontrunnerIoC) -> FundExternalSubaccountResponse:
+    subaccount = self.request.destination_subaccount
+    response = await deps.injective_chain.fund_subaccount(
+      await deps.wallet(), subaccount.subaccount_id, self.request.amount, self.request.denom
+    )
+
+    return FundExternalSubaccountResponse(transaction=response.txhash)

--- a/frontrunner_sdk/commands/injective/fund_external_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_external_subaccount.py
@@ -30,7 +30,8 @@ class FundExternalSubaccountOperation(FrontrunnerOperation[FundExternalSubaccoun
 
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> FundExternalSubaccountResponse:
-    source_subaccount = Subaccount.from_wallet_and_index(await deps.wallet(), self.request.source_subaccount_index)
+    wallet = await deps.wallet()
+    source_subaccount = wallet.subaccount(self.request.source_subaccount_index)
     destination_subaccount = self.request.destination_subaccount
     # Use fund_subaccount_from_bank (MsgDeposit) to send from bank balance shared with subaccount 0 because
     # fund_external_subaccount (MsgExternalTransfer) doesn't work from subaccount 0

--- a/frontrunner_sdk/commands/injective/fund_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_subaccount.py
@@ -27,9 +27,10 @@ class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSu
 
   def validate(self, deps: FrontrunnerIoC) -> None:
     if self.request.destination_subaccount_index is None and self.request.destination_subaccount is None:
-      raise FrontrunnerArgumentException("Must specify either subaccount_index or subaccount")
+      raise FrontrunnerArgumentException("Must specify either destination_subaccount_index or destination_subaccount")
     validate_mutually_exclusive(
-      "subaccount_index", self.request.destination_subaccount_index, "subaccount", self.request.destination_subaccount
+      "destination_subaccount_index", self.request.destination_subaccount_index, "destination_subaccount",
+      self.request.destination_subaccount
     )
 
   def __init__(self, request: FundSubaccountRequest):
@@ -44,7 +45,7 @@ class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSu
         await deps.wallet(),
         self.request.destination_subaccount_index # type: ignore[arg-type]
       )
-    # Use fund_subaccount_from_subaccount (MsgSubaccountTransfer) if source subaccount is provided.
+    # Use fund_subaccount_from_subaccount (MsgSubaccountTransfer) if source subaccount is provided and non-zero.
     # Otherwise, use fund_subaccount_from_bank (MsgDeposit).
     if self.request.source_subaccount_index:
       source_subaccount = Subaccount.from_wallet_and_index(

--- a/frontrunner_sdk/commands/injective/fund_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_subaccount.py
@@ -28,6 +28,10 @@ class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSu
   def validate(self, deps: FrontrunnerIoC) -> None:
     if self.request.destination_subaccount_index is None and self.request.destination_subaccount is None:
       raise FrontrunnerArgumentException("Must specify either destination_subaccount_index or destination_subaccount")
+    if self.request.destination_subaccount_index == 0:
+      raise FrontrunnerArgumentException("destination_subaccount_index must be > 0 if provided", destination_subaccount_index=self.request.destination_subaccount_index)
+    if self.request.destination_subaccount and self.request.destination_subaccount.subaccount_id.endswith("0" * 24):
+      raise FrontrunnerArgumentException("destination_subaccount must not be default 0 subaccount", destination_subaccount=self.request.destination_subaccount)
     validate_mutually_exclusive(
       "destination_subaccount_index", self.request.destination_subaccount_index, "destination_subaccount",
       self.request.destination_subaccount

--- a/frontrunner_sdk/commands/injective/fund_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_subaccount.py
@@ -51,17 +51,13 @@ class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSu
     if self.request.destination_subaccount:
       destination_subaccount = self.request.destination_subaccount
     else:
-      destination_subaccount = Subaccount.from_wallet_and_index(
-        await deps.wallet(),
-        self.request.destination_subaccount_index # type: ignore[arg-type]
-      )
+      wallet = await deps.wallet()
+      destination_subaccount = wallet.subaccount(self.request.destination_subaccount_index) # type: ignore[arg-type]
     # Use fund_subaccount_from_subaccount (MsgSubaccountTransfer) if source subaccount is provided and non-zero.
     # Otherwise, use fund_subaccount_from_bank (MsgDeposit).
     if self.request.source_subaccount_index:
-      source_subaccount = Subaccount.from_wallet_and_index(
-        await deps.wallet(),
-        self.request.source_subaccount_index,
-      )
+      wallet = await deps.wallet()
+      source_subaccount = wallet.subaccount(self.request.source_subaccount_index)
       response = await deps.injective_chain.fund_subaccount_from_subaccount(
         await deps.wallet(), source_subaccount.subaccount_id, destination_subaccount.subaccount_id, self.request.amount,
         self.request.denom

--- a/frontrunner_sdk/commands/injective/fund_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_subaccount.py
@@ -13,8 +13,9 @@ from frontrunner_sdk.models import Subaccount
 class FundSubaccountRequest:
   amount: int
   denom: str
-  subaccount_index: Optional[int] = None
-  subaccount: Optional[Subaccount] = None
+  source_subaccount_index: Optional[int] = None
+  destination_subaccount_index: Optional[int] = None
+  destination_subaccount: Optional[Subaccount] = None
 
 
 @dataclass
@@ -25,10 +26,10 @@ class FundSubaccountResponse:
 class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSubaccountResponse]):
 
   def validate(self, deps: FrontrunnerIoC) -> None:
-    if self.request.subaccount_index is None and self.request.subaccount is None:
+    if self.request.destination_subaccount_index is None and self.request.destination_subaccount is None:
       raise FrontrunnerArgumentException("Must specify either subaccount_index or subaccount")
     validate_mutually_exclusive(
-      "subaccount_index", self.request.subaccount_index, "subaccount", self.request.subaccount
+      "subaccount_index", self.request.destination_subaccount_index, "subaccount", self.request.destination_subaccount
     )
 
   def __init__(self, request: FundSubaccountRequest):
@@ -36,12 +37,27 @@ class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSu
 
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> FundSubaccountResponse:
-    subaccount = self.request.subaccount if self.request.subaccount else Subaccount.from_wallet_and_index(
-      await deps.wallet(),
-      self.request.subaccount_index # type: ignore[arg-type]
-    )
-    response = await deps.injective_chain.fund_subaccount(
-      await deps.wallet(), subaccount.subaccount_id, self.request.amount, self.request.denom
-    )
+    if self.request.destination_subaccount:
+      destination_subaccount = self.request.destination_subaccount
+    else:
+      destination_subaccount = Subaccount.from_wallet_and_index(
+        await deps.wallet(),
+        self.request.destination_subaccount_index # type: ignore[arg-type]
+      )
+    # Use fund_subaccount_from_subaccount (MsgSubaccountTransfer) if source subaccount is provided.
+    # Otherwise, use fund_subaccount_from_bank (MsgDeposit).
+    if self.request.source_subaccount_index:
+      source_subaccount = Subaccount.from_wallet_and_index(
+        await deps.wallet(),
+        self.request.source_subaccount_index,
+      )
+      response = await deps.injective_chain.fund_subaccount_from_subaccount(
+        await deps.wallet(), source_subaccount.subaccount_id, destination_subaccount.subaccount_id, self.request.amount,
+        self.request.denom
+      )
+    else:
+      response = await deps.injective_chain.fund_subaccount_from_bank(
+        await deps.wallet(), destination_subaccount.subaccount_id, self.request.amount, self.request.denom
+      )
 
     return FundSubaccountResponse(transaction=response.txhash)

--- a/frontrunner_sdk/commands/injective/fund_subaccount.py
+++ b/frontrunner_sdk/commands/injective/fund_subaccount.py
@@ -29,9 +29,15 @@ class FundSubaccountOperation(FrontrunnerOperation[FundSubaccountRequest, FundSu
     if self.request.destination_subaccount_index is None and self.request.destination_subaccount is None:
       raise FrontrunnerArgumentException("Must specify either destination_subaccount_index or destination_subaccount")
     if self.request.destination_subaccount_index == 0:
-      raise FrontrunnerArgumentException("destination_subaccount_index must be > 0 if provided", destination_subaccount_index=self.request.destination_subaccount_index)
+      raise FrontrunnerArgumentException(
+        "destination_subaccount_index must be > 0 if provided",
+        destination_subaccount_index=self.request.destination_subaccount_index
+      )
     if self.request.destination_subaccount and self.request.destination_subaccount.subaccount_id.endswith("0" * 24):
-      raise FrontrunnerArgumentException("destination_subaccount must not be default 0 subaccount", destination_subaccount=self.request.destination_subaccount)
+      raise FrontrunnerArgumentException(
+        "destination_subaccount must not be default 0 subaccount",
+        destination_subaccount=self.request.destination_subaccount
+      )
     validate_mutually_exclusive(
       "destination_subaccount_index", self.request.destination_subaccount_index, "destination_subaccount",
       self.request.destination_subaccount

--- a/frontrunner_sdk/commands/injective/withdraw_from_subaccount.py
+++ b/frontrunner_sdk/commands/injective/withdraw_from_subaccount.py
@@ -2,8 +2,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 from frontrunner_sdk.commands.base import FrontrunnerOperation
-from frontrunner_sdk.exceptions import FrontrunnerArgumentException
-from frontrunner_sdk.helpers.validation import validate_mutually_exclusive
 from frontrunner_sdk.ioc import FrontrunnerIoC
 from frontrunner_sdk.logging.log_operation import log_operation
 from frontrunner_sdk.models import Subaccount
@@ -21,7 +19,8 @@ class WithdrawFromSubaccountResponse:
   transaction: str
 
 
-class WithdrawFromSubaccountOperation(FrontrunnerOperation[WithdrawFromSubaccountRequest, WithdrawFromSubaccountResponse]):
+class WithdrawFromSubaccountOperation(FrontrunnerOperation[WithdrawFromSubaccountRequest,
+                                                           WithdrawFromSubaccountResponse]):
 
   def validate(self, deps: FrontrunnerIoC) -> None:
     pass
@@ -31,7 +30,10 @@ class WithdrawFromSubaccountOperation(FrontrunnerOperation[WithdrawFromSubaccoun
 
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> WithdrawFromSubaccountResponse:
-    subaccount = Subaccount.from_wallet_and_index(await deps.wallet(), self.request.subaccount_index)
+    subaccount = Subaccount.from_wallet_and_index(
+      await deps.wallet(),
+      self.request.subaccount_index # type: ignore[arg-type]
+    )
     response = await deps.injective_chain.withdraw_from_subaccount(
       await deps.wallet(), subaccount.subaccount_id, self.request.amount, self.request.denom
     )

--- a/frontrunner_sdk/commands/injective/withdraw_from_subaccount.py
+++ b/frontrunner_sdk/commands/injective/withdraw_from_subaccount.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from typing import Optional
+
+from frontrunner_sdk.commands.base import FrontrunnerOperation
+from frontrunner_sdk.exceptions import FrontrunnerArgumentException
+from frontrunner_sdk.helpers.validation import validate_mutually_exclusive
+from frontrunner_sdk.ioc import FrontrunnerIoC
+from frontrunner_sdk.logging.log_operation import log_operation
+from frontrunner_sdk.models import Subaccount
+
+
+@dataclass
+class WithdrawFromSubaccountRequest:
+  amount: int
+  denom: str
+  subaccount_index: Optional[int] = None
+
+
+@dataclass
+class WithdrawFromSubaccountResponse:
+  transaction: str
+
+
+class WithdrawFromSubaccountOperation(FrontrunnerOperation[WithdrawFromSubaccountRequest, WithdrawFromSubaccountResponse]):
+
+  def validate(self, deps: FrontrunnerIoC) -> None:
+    pass
+
+  def __init__(self, request: WithdrawFromSubaccountRequest):
+    super().__init__(request)
+
+  @log_operation(__name__)
+  async def execute(self, deps: FrontrunnerIoC) -> WithdrawFromSubaccountResponse:
+    subaccount = Subaccount.from_wallet_and_index(await deps.wallet(), self.request.subaccount_index)
+    response = await deps.injective_chain.withdraw_from_subaccount(
+      await deps.wallet(), subaccount.subaccount_id, self.request.amount, self.request.denom
+    )
+
+    return WithdrawFromSubaccountResponse(transaction=response.txhash)

--- a/frontrunner_sdk/commands/injective/withdraw_from_subaccount.py
+++ b/frontrunner_sdk/commands/injective/withdraw_from_subaccount.py
@@ -4,7 +4,6 @@ from frontrunner_sdk.commands.base import FrontrunnerOperation
 from frontrunner_sdk.exceptions import FrontrunnerArgumentException
 from frontrunner_sdk.ioc import FrontrunnerIoC
 from frontrunner_sdk.logging.log_operation import log_operation
-from frontrunner_sdk.models import Subaccount
 
 
 @dataclass
@@ -34,7 +33,8 @@ class WithdrawFromSubaccountOperation(FrontrunnerOperation[WithdrawFromSubaccoun
 
   @log_operation(__name__)
   async def execute(self, deps: FrontrunnerIoC) -> WithdrawFromSubaccountResponse:
-    subaccount = Subaccount.from_wallet_and_index(await deps.wallet(), self.request.subaccount_index)
+    wallet = await deps.wallet()
+    subaccount = wallet.subaccount(self.request.subaccount_index)
     response = await deps.injective_chain.withdraw_from_subaccount(
       await deps.wallet(), subaccount.subaccount_id, self.request.amount, self.request.denom
     )

--- a/frontrunner_sdk/facades/injective.py
+++ b/frontrunner_sdk/facades/injective.py
@@ -52,6 +52,8 @@ from frontrunner_sdk.commands.injective.stream_positions import StreamPositionsR
 from frontrunner_sdk.commands.injective.stream_trades import StreamTradesOperation # NOQA
 from frontrunner_sdk.commands.injective.stream_trades import StreamTradesRequest # NOQA
 from frontrunner_sdk.commands.injective.stream_trades import StreamTradesResponse # NOQA
+from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountResponse, WithdrawFromSubaccountRequest, \
+  WithdrawFromSubaccountOperation
 from frontrunner_sdk.facades.base import FrontrunnerFacadeMixin # NOQA
 from frontrunner_sdk.helpers.parameters import as_request_args
 from frontrunner_sdk.ioc import FrontrunnerIoC
@@ -214,6 +216,15 @@ class InjectiveFacadeAsync(FrontrunnerFacadeMixin):
     request = StreamPositionsRequest(**kwargs)
     return await self._run_operation(StreamPositionsOperation, self.deps, request)
 
+  async def withdraw_from_subaccount(
+      self,
+      amount: int,
+      denom: str,
+      subaccount_index: int,
+  ) -> WithdrawFromSubaccountResponse:
+    request = WithdrawFromSubaccountRequest(amount, denom, subaccount_index=subaccount_index)
+    return await self._run_operation(WithdrawFromSubaccountOperation, self.deps, request)
+
 
 class InjectiveFacade(SyncMixin):
 
@@ -313,3 +324,11 @@ class InjectiveFacade(SyncMixin):
   ) -> GetTradesResponse:
     kwargs = as_request_args(locals())
     return self._synchronously(self.impl.get_trades, **kwargs)
+
+  def withdraw_from_subaccount(
+      self,
+      amount: int,
+      denom: str,
+      subaccount_index: int,
+  ) -> WithdrawFromSubaccountResponse:
+    return self._synchronously(self.impl.withdraw_from_subaccount, amount, denom, subaccount_index)

--- a/frontrunner_sdk/facades/injective.py
+++ b/frontrunner_sdk/facades/injective.py
@@ -16,8 +16,9 @@ from frontrunner_sdk.commands.injective.create_orders import CreateOrdersRespons
 from frontrunner_sdk.commands.injective.create_wallet import CreateWalletOperation # NOQA
 from frontrunner_sdk.commands.injective.create_wallet import CreateWalletRequest # NOQA
 from frontrunner_sdk.commands.injective.create_wallet import CreateWalletResponse # NOQA
-from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountResponse, FundExternalSubaccountRequest, \
-  FundExternalSubaccountOperation
+from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountOperation # NOQA
+from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountRequest # NOQA
+from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountResponse # NOQA
 from frontrunner_sdk.commands.injective.fund_subaccount import FundSubaccountOperation # NOQA
 from frontrunner_sdk.commands.injective.fund_subaccount import FundSubaccountRequest # NOQA
 from frontrunner_sdk.commands.injective.fund_subaccount import FundSubaccountResponse # NOQA
@@ -73,11 +74,11 @@ class InjectiveFacadeAsync(FrontrunnerFacadeMixin):
     return await self._run_operation(CreateWalletOperation, self.deps, request)
 
   async def fund_external_subaccount(
-      self,
-      amount: int,
-      denom: str,
-      destination_subaccount: Subaccount,
-      source_subaccount_index: Optional[int] = None,
+    self,
+    amount: int,
+    denom: str,
+    destination_subaccount: Subaccount,
+    source_subaccount_index: Optional[int] = None,
   ) -> FundExternalSubaccountResponse:
     request = FundExternalSubaccountRequest(amount, denom, source_subaccount_index or 0, destination_subaccount)
     return await self._run_operation(FundExternalSubaccountOperation, self.deps, request)
@@ -223,22 +224,30 @@ class InjectiveFacade(SyncMixin):
     return self._synchronously(self.impl.create_wallet)
 
   def fund_external_subaccount(
-      self,
-      amount: int,
-      denom: str,
-      destination_subaccount: Subaccount,
-      source_subaccount_index: Optional[int] = None,
+    self,
+    amount: int,
+    denom: str,
+    destination_subaccount: Subaccount,
+    source_subaccount_index: Optional[int] = None,
   ) -> FundExternalSubaccountResponse:
-    return self._synchronously(self.impl.fund_external_subaccount, amount, denom, destination_subaccount, source_subaccount_index=source_subaccount_index)
+    return self._synchronously(
+      self.impl.fund_external_subaccount,
+      amount,
+      denom,
+      destination_subaccount,
+      source_subaccount_index=source_subaccount_index
+    )
 
   def fund_subaccount(
-      self,
-      amount: int,
-      denom: str,
-      subaccount_index: Optional[int] = None,
-      subaccount: Optional[Subaccount] = None,
+    self,
+    amount: int,
+    denom: str,
+    subaccount_index: Optional[int] = None,
+    subaccount: Optional[Subaccount] = None,
   ) -> FundSubaccountResponse:
-    return self._synchronously(self.impl.fund_subaccount, amount, denom, subaccount_index=subaccount_index, subaccount=subaccount)
+    return self._synchronously(
+      self.impl.fund_subaccount, amount, denom, subaccount_index=subaccount_index, subaccount=subaccount
+    )
 
   def fund_wallet_from_faucet(self) -> FundWalletFromFaucetResponse:
     return self._synchronously(self.impl.fund_wallet_from_faucet)

--- a/frontrunner_sdk/facades/injective.py
+++ b/frontrunner_sdk/facades/injective.py
@@ -16,6 +16,8 @@ from frontrunner_sdk.commands.injective.create_orders import CreateOrdersRespons
 from frontrunner_sdk.commands.injective.create_wallet import CreateWalletOperation # NOQA
 from frontrunner_sdk.commands.injective.create_wallet import CreateWalletRequest # NOQA
 from frontrunner_sdk.commands.injective.create_wallet import CreateWalletResponse # NOQA
+from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountResponse, FundExternalSubaccountRequest, \
+  FundExternalSubaccountOperation
 from frontrunner_sdk.commands.injective.fund_subaccount import FundSubaccountOperation # NOQA
 from frontrunner_sdk.commands.injective.fund_subaccount import FundSubaccountRequest # NOQA
 from frontrunner_sdk.commands.injective.fund_subaccount import FundSubaccountResponse # NOQA
@@ -69,6 +71,16 @@ class InjectiveFacadeAsync(FrontrunnerFacadeMixin):
   async def create_wallet(self, fund_and_initialize: bool = True) -> CreateWalletResponse:
     request = CreateWalletRequest(fund_and_initialize=fund_and_initialize)
     return await self._run_operation(CreateWalletOperation, self.deps, request)
+
+  async def fund_external_subaccount(
+      self,
+      amount: int,
+      denom: str,
+      destination_subaccount: Subaccount,
+      source_subaccount_index: Optional[int] = None,
+  ) -> FundExternalSubaccountResponse:
+    request = FundExternalSubaccountRequest(amount, denom, source_subaccount_index or 0, destination_subaccount)
+    return await self._run_operation(FundExternalSubaccountOperation, self.deps, request)
 
   async def fund_subaccount(
     self,
@@ -209,6 +221,24 @@ class InjectiveFacade(SyncMixin):
 
   def create_wallet(self) -> CreateWalletResponse:
     return self._synchronously(self.impl.create_wallet)
+
+  def fund_external_subaccount(
+      self,
+      amount: int,
+      denom: str,
+      destination_subaccount: Subaccount,
+      source_subaccount_index: Optional[int] = None,
+  ) -> FundExternalSubaccountResponse:
+    return self._synchronously(self.impl.fund_external_subaccount, amount, denom, destination_subaccount, source_subaccount_index=source_subaccount_index)
+
+  def fund_subaccount(
+      self,
+      amount: int,
+      denom: str,
+      subaccount_index: Optional[int] = None,
+      subaccount: Optional[Subaccount] = None,
+  ) -> FundSubaccountResponse:
+    return self._synchronously(self.impl.fund_subaccount, amount, denom, subaccount_index=subaccount_index, subaccount=subaccount)
 
   def fund_wallet_from_faucet(self) -> FundWalletFromFaucetResponse:
     return self._synchronously(self.impl.fund_wallet_from_faucet)

--- a/frontrunner_sdk/facades/injective.py
+++ b/frontrunner_sdk/facades/injective.py
@@ -52,8 +52,9 @@ from frontrunner_sdk.commands.injective.stream_positions import StreamPositionsR
 from frontrunner_sdk.commands.injective.stream_trades import StreamTradesOperation # NOQA
 from frontrunner_sdk.commands.injective.stream_trades import StreamTradesRequest # NOQA
 from frontrunner_sdk.commands.injective.stream_trades import StreamTradesResponse # NOQA
-from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountResponse, WithdrawFromSubaccountRequest, \
-  WithdrawFromSubaccountOperation
+from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountOperation # NOQA
+from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountRequest # NOQA
+from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountResponse # NOQA
 from frontrunner_sdk.facades.base import FrontrunnerFacadeMixin # NOQA
 from frontrunner_sdk.helpers.parameters import as_request_args
 from frontrunner_sdk.ioc import FrontrunnerIoC
@@ -89,10 +90,17 @@ class InjectiveFacadeAsync(FrontrunnerFacadeMixin):
     self,
     amount: int,
     denom: str,
-    subaccount_index: Optional[int] = None,
-    subaccount: Optional[Subaccount] = None,
+    source_subaccount_index: Optional[int] = None,
+    destination_subaccount_index: Optional[int] = None,
+    destination_subaccount: Optional[Subaccount] = None,
   ) -> FundSubaccountResponse:
-    request = FundSubaccountRequest(amount, denom, subaccount=subaccount, subaccount_index=subaccount_index)
+    request = FundSubaccountRequest(
+      amount,
+      denom,
+      source_subaccount_index=source_subaccount_index,
+      destination_subaccount=destination_subaccount,
+      destination_subaccount_index=destination_subaccount_index
+    )
     return await self._run_operation(FundSubaccountOperation, self.deps, request)
 
   async def fund_wallet_from_faucet(self) -> FundWalletFromFaucetResponse:
@@ -217,10 +225,10 @@ class InjectiveFacadeAsync(FrontrunnerFacadeMixin):
     return await self._run_operation(StreamPositionsOperation, self.deps, request)
 
   async def withdraw_from_subaccount(
-      self,
-      amount: int,
-      denom: str,
-      subaccount_index: int,
+    self,
+    amount: int,
+    denom: str,
+    subaccount_index: int,
   ) -> WithdrawFromSubaccountResponse:
     request = WithdrawFromSubaccountRequest(amount, denom, subaccount_index=subaccount_index)
     return await self._run_operation(WithdrawFromSubaccountOperation, self.deps, request)
@@ -253,11 +261,17 @@ class InjectiveFacade(SyncMixin):
     self,
     amount: int,
     denom: str,
-    subaccount_index: Optional[int] = None,
-    subaccount: Optional[Subaccount] = None,
+    source_subaccount_index: Optional[int] = None,
+    destination_subaccount_index: Optional[int] = None,
+    destination_subaccount: Optional[Subaccount] = None,
   ) -> FundSubaccountResponse:
     return self._synchronously(
-      self.impl.fund_subaccount, amount, denom, subaccount_index=subaccount_index, subaccount=subaccount
+      self.impl.fund_subaccount,
+      amount,
+      denom,
+      source_subaccount_index=source_subaccount_index,
+      destination_subaccount_index=destination_subaccount_index,
+      destination_subaccount=destination_subaccount
     )
 
   def fund_wallet_from_faucet(self) -> FundWalletFromFaucetResponse:
@@ -326,9 +340,9 @@ class InjectiveFacade(SyncMixin):
     return self._synchronously(self.impl.get_trades, **kwargs)
 
   def withdraw_from_subaccount(
-      self,
-      amount: int,
-      denom: str,
-      subaccount_index: int,
+    self,
+    amount: int,
+    denom: str,
+    subaccount_index: int,
   ) -> WithdrawFromSubaccountResponse:
     return self._synchronously(self.impl.withdraw_from_subaccount, amount, denom, subaccount_index)

--- a/tests/commands/injective/test_cancel_orders.py
+++ b/tests/commands/injective/test_cancel_orders.py
@@ -8,7 +8,6 @@ from frontrunner_sdk.commands.injective.cancel_orders import CancelOrdersOperati
 from frontrunner_sdk.commands.injective.cancel_orders import CancelOrdersRequest # NOQA
 from frontrunner_sdk.ioc import FrontrunnerIoC
 from frontrunner_sdk.models.cancel_order import CancelOrder
-from frontrunner_sdk.models.wallet import Subaccount
 from frontrunner_sdk.models.wallet import Wallet
 
 
@@ -32,7 +31,7 @@ class TestCancelOrdersOperation(IsolatedAsyncioTestCase):
 
   async def test_cancel_all_orders(self):
     wallet = Wallet._new()
-    subaccount = Subaccount.from_wallet_and_index(wallet, 0)
+    subaccount = wallet.subaccount(0)
 
     self.deps.wallet = AsyncMock(return_value=wallet)
     self.deps.injective_chain.get_all_open_orders = AsyncMock(return_value=self.order_responses)
@@ -53,7 +52,7 @@ class TestCancelOrdersOperation(IsolatedAsyncioTestCase):
   async def test_cancel_all_orders_subaccount_index(self):
     subaccount_index = 2
     wallet = Wallet._new()
-    subaccount = Subaccount.from_wallet_and_index(wallet, subaccount_index)
+    subaccount = wallet.subaccount(subaccount_index)
 
     self.deps.wallet = AsyncMock(return_value=wallet)
     self.deps.injective_chain.get_all_open_orders = AsyncMock(return_value=self.order_responses)

--- a/tests/commands/injective/test_fund_external_subaccount.py
+++ b/tests/commands/injective/test_fund_external_subaccount.py
@@ -28,7 +28,7 @@ class TestFundExternalSubaccountOperation(IsolatedAsyncioTestCase):
 
   async def test_fund_external_subaccount_nonzero_source_index(self):
     source_subaccount_index = 1
-    source_subaccount = Subaccount.from_wallet_and_index(self.wallet, source_subaccount_index)
+    source_subaccount = self.wallet.subaccount(source_subaccount_index)
     self.deps.injective_chain.fund_external_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
 
     req = FundExternalSubaccountRequest(

--- a/tests/commands/injective/test_fund_external_subaccount.py
+++ b/tests/commands/injective/test_fund_external_subaccount.py
@@ -1,0 +1,62 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from frontrunner_sdk import Wallet
+from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountOperation # NOQA
+from frontrunner_sdk.commands.injective.fund_external_subaccount import FundExternalSubaccountRequest # NOQA
+from frontrunner_sdk.exceptions import FrontrunnerArgumentException # NOQA
+from frontrunner_sdk.ioc import FrontrunnerIoC
+from frontrunner_sdk.models import Subaccount
+
+
+class TestFundExternalSubaccountOperation(IsolatedAsyncioTestCase):
+
+  def setUp(self) -> None:
+    self.deps = MagicMock(spec=FrontrunnerIoC)
+    self.destination_subaccount_id = "0xfddd3e6d98a236a1df56716ab8c407b1004113df000000000000000000000000"
+    self.destination_subaccount = Subaccount.from_subaccount_id(self.destination_subaccount_id)
+    self.wallet = Wallet._new()
+    self.deps.wallet = AsyncMock(return_value=self.wallet)
+
+  def test_validate(self):
+    req = FundExternalSubaccountRequest(
+      amount=10, denom="FRCOIN", source_subaccount_index=0, destination_subaccount=self.destination_subaccount
+    )
+    cmd = FundExternalSubaccountOperation(req)
+    cmd.validate(self.deps)
+
+  async def test_fund_external_subaccount_nonzero_source_index(self):
+    source_subaccount_index = 1
+    source_subaccount = Subaccount.from_wallet_and_index(self.wallet, source_subaccount_index)
+    self.deps.injective_chain.fund_external_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
+
+    req = FundExternalSubaccountRequest(
+      amount=10,
+      denom="FRCOIN",
+      source_subaccount_index=source_subaccount_index,
+      destination_subaccount=self.destination_subaccount
+    )
+    cmd = FundExternalSubaccountOperation(req)
+    res = await cmd.execute(self.deps)
+
+    self.assertEqual(res.transaction, "<txhash>")
+
+    self.deps.injective_chain.fund_external_subaccount.assert_awaited_once_with(
+      await self.deps.wallet(), source_subaccount.subaccount_id, self.destination_subaccount_id, 10, "FRCOIN"
+    )
+
+  async def test_fund_external_subaccount_from_bank_zero_index(self):
+    self.deps.injective_chain.fund_subaccount_from_bank = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
+
+    req = FundExternalSubaccountRequest(
+      amount=10, denom="FRCOIN", source_subaccount_index=0, destination_subaccount=self.destination_subaccount
+    )
+    cmd = FundExternalSubaccountOperation(req)
+    res = await cmd.execute(self.deps)
+
+    self.assertEqual(res.transaction, "<txhash>")
+
+    self.deps.injective_chain.fund_subaccount_from_bank.assert_awaited_once_with(
+      await self.deps.wallet(), self.destination_subaccount.subaccount_id, 10, "FRCOIN"
+    )

--- a/tests/commands/injective/test_fund_subaccount.py
+++ b/tests/commands/injective/test_fund_subaccount.py
@@ -64,3 +64,26 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
     self.deps.injective_chain.fund_subaccount_from_bank.assert_awaited_once_with(
       await self.deps.wallet(), subaccount.subaccount_id, 10, "FRCOIN"
     )
+
+  async def test_fund_subaccount_source_index(self):
+    source_subaccount_index = 2
+    wallet = Wallet._new()
+    source_subaccount = Subaccount.from_wallet_and_index(wallet, source_subaccount_index)
+
+    self.deps.wallet = AsyncMock(return_value=wallet)
+    self.deps.injective_chain.fund_subaccount_from_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
+
+    req = FundSubaccountRequest(
+      amount=10,
+      denom="FRCOIN",
+      source_subaccount_index=source_subaccount_index,
+      destination_subaccount=self.subaccount
+    )
+    cmd = FundSubaccountOperation(req)
+    res = await cmd.execute(self.deps)
+
+    self.assertEqual(res.transaction, "<txhash>")
+
+    self.deps.injective_chain.fund_subaccount_from_subaccount.assert_awaited_once_with(
+      await self.deps.wallet(), source_subaccount.subaccount_id, self.subaccount_id, 10, "FRCOIN"
+    )

--- a/tests/commands/injective/test_fund_subaccount.py
+++ b/tests/commands/injective/test_fund_subaccount.py
@@ -36,15 +36,18 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
 
   def test_validate_subaccount_0_exceptions(self):
     with self.assertRaises(FrontrunnerArgumentException):
-      FundSubaccountOperation(
-        FundSubaccountRequest(
-          amount=10, denom="FRCOIN", destination_subaccount_index=0,
-        )
-      ).validate(self.deps)
+      FundSubaccountOperation(FundSubaccountRequest(
+        amount=10,
+        denom="FRCOIN",
+        destination_subaccount_index=0,
+      )).validate(self.deps)
     with self.assertRaises(FrontrunnerArgumentException):
       FundSubaccountOperation(
         FundSubaccountRequest(
-          amount=10, denom="FRCOIN", destination_subaccount=Subaccount.from_subaccount_id("0xfddd3e6d98a236a1df56716ab8c407b1004113df000000000000000000000000"),
+          amount=10,
+          denom="FRCOIN",
+          destination_subaccount=Subaccount.
+          from_subaccount_id("0xfddd3e6d98a236a1df56716ab8c407b1004113df000000000000000000000000"),
         )
       ).validate(self.deps)
 

--- a/tests/commands/injective/test_fund_subaccount.py
+++ b/tests/commands/injective/test_fund_subaccount.py
@@ -33,7 +33,7 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
       ).validate(self.deps)
 
   async def test_fund_subaccount(self):
-    self.deps.injective_chain.fund_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
+    self.deps.injective_chain.fund_subaccount_from_bank = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
 
     req = FundSubaccountRequest(amount=10, denom="FRCOIN", subaccount=self.subaccount)
     cmd = FundSubaccountOperation(req)
@@ -41,7 +41,7 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
 
     self.assertEqual(res.transaction, "<txhash>")
 
-    self.deps.injective_chain.fund_subaccount.assert_awaited_once_with(
+    self.deps.injective_chain.fund_subaccount_from_bank.assert_awaited_once_with(
       await self.deps.wallet(), self.subaccount_id, 10, "FRCOIN"
     )
 
@@ -51,7 +51,7 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
     subaccount = Subaccount.from_wallet_and_index(wallet, subaccount_index)
 
     self.deps.wallet = AsyncMock(return_value=wallet)
-    self.deps.injective_chain.fund_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
+    self.deps.injective_chain.fund_subaccount_from_bank = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
 
     req = FundSubaccountRequest(amount=10, denom="FRCOIN", subaccount_index=subaccount_index)
     cmd = FundSubaccountOperation(req)
@@ -59,6 +59,6 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
 
     self.assertEqual(res.transaction, "<txhash>")
 
-    self.deps.injective_chain.fund_subaccount.assert_awaited_once_with(
+    self.deps.injective_chain.fund_subaccount_from_bank.assert_awaited_once_with(
       await self.deps.wallet(), subaccount.subaccount_id, 10, "FRCOIN"
     )

--- a/tests/commands/injective/test_fund_subaccount.py
+++ b/tests/commands/injective/test_fund_subaccount.py
@@ -67,7 +67,7 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
   async def test_fund_subaccount_by_index(self):
     destination_subaccount_index = 2
     wallet = Wallet._new()
-    subaccount = Subaccount.from_wallet_and_index(wallet, destination_subaccount_index)
+    subaccount = wallet.subaccount(destination_subaccount_index)
 
     self.deps.wallet = AsyncMock(return_value=wallet)
     self.deps.injective_chain.fund_subaccount_from_bank = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
@@ -85,7 +85,7 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
   async def test_fund_subaccount_source_index(self):
     source_subaccount_index = 2
     wallet = Wallet._new()
-    source_subaccount = Subaccount.from_wallet_and_index(wallet, source_subaccount_index)
+    source_subaccount = wallet.subaccount(source_subaccount_index)
 
     self.deps.wallet = AsyncMock(return_value=wallet)
     self.deps.injective_chain.fund_subaccount_from_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))

--- a/tests/commands/injective/test_fund_subaccount.py
+++ b/tests/commands/injective/test_fund_subaccount.py
@@ -18,7 +18,7 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
     self.subaccount = Subaccount.from_subaccount_id(self.subaccount_id)
 
   def test_validate(self):
-    req = FundSubaccountRequest(amount=10, denom="FRCOIN", subaccount_index=0)
+    req = FundSubaccountRequest(amount=10, denom="FRCOIN", destination_subaccount_index=0)
     cmd = FundSubaccountOperation(req)
     cmd.validate(self.deps)
 
@@ -29,13 +29,15 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
   def test_validate_both_subaccounts_exception(self):
     with self.assertRaises(FrontrunnerArgumentException):
       FundSubaccountOperation(
-        FundSubaccountRequest(amount=10, denom="FRCOIN", subaccount_index=0, subaccount=self.subaccount)
+        FundSubaccountRequest(
+          amount=10, denom="FRCOIN", destination_subaccount_index=0, destination_subaccount=self.subaccount
+        )
       ).validate(self.deps)
 
   async def test_fund_subaccount(self):
     self.deps.injective_chain.fund_subaccount_from_bank = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
 
-    req = FundSubaccountRequest(amount=10, denom="FRCOIN", subaccount=self.subaccount)
+    req = FundSubaccountRequest(amount=10, denom="FRCOIN", destination_subaccount=self.subaccount)
     cmd = FundSubaccountOperation(req)
     res = await cmd.execute(self.deps)
 
@@ -46,14 +48,14 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
     )
 
   async def test_fund_subaccount_by_index(self):
-    subaccount_index = 2
+    destination_subaccount_index = 2
     wallet = Wallet._new()
-    subaccount = Subaccount.from_wallet_and_index(wallet, subaccount_index)
+    subaccount = Subaccount.from_wallet_and_index(wallet, destination_subaccount_index)
 
     self.deps.wallet = AsyncMock(return_value=wallet)
     self.deps.injective_chain.fund_subaccount_from_bank = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
 
-    req = FundSubaccountRequest(amount=10, denom="FRCOIN", subaccount_index=subaccount_index)
+    req = FundSubaccountRequest(amount=10, denom="FRCOIN", destination_subaccount_index=destination_subaccount_index)
     cmd = FundSubaccountOperation(req)
     res = await cmd.execute(self.deps)
 

--- a/tests/commands/injective/test_fund_subaccount.py
+++ b/tests/commands/injective/test_fund_subaccount.py
@@ -14,11 +14,11 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
 
   def setUp(self) -> None:
     self.deps = MagicMock(spec=FrontrunnerIoC)
-    self.subaccount_id = "0xfddd3e6d98a236a1df56716ab8c407b1004113df000000000000000000000000"
+    self.subaccount_id = "0xfddd3e6d98a236a1df56716ab8c407b1004113df000000000000000000000001"
     self.subaccount = Subaccount.from_subaccount_id(self.subaccount_id)
 
   def test_validate(self):
-    req = FundSubaccountRequest(amount=10, denom="FRCOIN", destination_subaccount_index=0)
+    req = FundSubaccountRequest(amount=10, denom="FRCOIN", destination_subaccount_index=1)
     cmd = FundSubaccountOperation(req)
     cmd.validate(self.deps)
 
@@ -30,7 +30,21 @@ class TestFundSubaccountOperation(IsolatedAsyncioTestCase):
     with self.assertRaises(FrontrunnerArgumentException):
       FundSubaccountOperation(
         FundSubaccountRequest(
-          amount=10, denom="FRCOIN", destination_subaccount_index=0, destination_subaccount=self.subaccount
+          amount=10, denom="FRCOIN", destination_subaccount_index=1, destination_subaccount=self.subaccount
+        )
+      ).validate(self.deps)
+
+  def test_validate_subaccount_0_exceptions(self):
+    with self.assertRaises(FrontrunnerArgumentException):
+      FundSubaccountOperation(
+        FundSubaccountRequest(
+          amount=10, denom="FRCOIN", destination_subaccount_index=0,
+        )
+      ).validate(self.deps)
+    with self.assertRaises(FrontrunnerArgumentException):
+      FundSubaccountOperation(
+        FundSubaccountRequest(
+          amount=10, denom="FRCOIN", destination_subaccount=Subaccount.from_subaccount_id("0xfddd3e6d98a236a1df56716ab8c407b1004113df000000000000000000000000"),
         )
       ).validate(self.deps)
 

--- a/tests/commands/injective/test_withdraw_from_subaccount.py
+++ b/tests/commands/injective/test_withdraw_from_subaccount.py
@@ -1,0 +1,49 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from frontrunner_sdk import Wallet
+from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountOperation # NOQA
+from frontrunner_sdk.commands.injective.withdraw_from_subaccount import WithdrawFromSubaccountRequest # NOQA
+from frontrunner_sdk.exceptions import FrontrunnerArgumentException # NOQA
+from frontrunner_sdk.ioc import FrontrunnerIoC
+
+
+class TestWithdrawFromSubaccountOperation(IsolatedAsyncioTestCase):
+
+  def setUp(self) -> None:
+    self.deps = MagicMock(spec=FrontrunnerIoC)
+    self.wallet = Wallet._new()
+    self.deps.wallet = AsyncMock(return_value=self.wallet)
+
+  def test_validate(self):
+    req = WithdrawFromSubaccountRequest(amount=10, denom="FRCOIN", subaccount_index=1)
+    cmd = WithdrawFromSubaccountOperation(req)
+    cmd.validate(self.deps)
+
+  def test_validate_fails(self):
+    with self.assertRaises(FrontrunnerArgumentException):
+      WithdrawFromSubaccountOperation(WithdrawFromSubaccountRequest(amount=10, denom="FRCOIN",
+                                                                    subaccount_index=0)).validate(self.deps)
+
+    with self.assertRaises(FrontrunnerArgumentException):
+      WithdrawFromSubaccountOperation(WithdrawFromSubaccountRequest(amount=10, denom="FRCOIN",
+                                                                    subaccount_index=None)).validate(self.deps)
+
+  async def test_withdraw_from_subaccount(self):
+    subaccount_index = 1
+    self.deps.injective_chain.withdraw_from_subaccount = AsyncMock(return_value=MagicMock(txhash="<txhash>"))
+
+    req = WithdrawFromSubaccountRequest(
+      amount=10,
+      denom="FRCOIN",
+      subaccount_index=subaccount_index,
+    )
+    cmd = WithdrawFromSubaccountOperation(req)
+    res = await cmd.execute(self.deps)
+
+    self.assertEqual(res.transaction, "<txhash>")
+
+    self.deps.injective_chain.withdraw_from_subaccount.assert_awaited_once_with(
+      await self.deps.wallet(), self.wallet.subaccount_address(subaccount_index), 10, "FRCOIN"
+    )


### PR DESCRIPTION
Adds the following operations:


| Operation                  | Usage                                                                                                                                                             | Notes                                                                                        |
|----------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
| `fund_external_subaccount` | Send funds to a subaccount that is NOT owned by the SDK wallet.                                                                                                   | Cannot fund subaccount 0.                                                                    |
| `fund_subaccount`          | Send funds from the main bank balance to a subaccount that IS owned by the SDK wallet. Or send funds between subaccounts that ARE BOTH owned by the SDK wallet.   | Cannot fund subaccount 0. Funding from source subaccount 0 sends from the main bank balance. |
| `withdraw_from_subaccount` | Withdraw funds from a subaccount that IS owned by the SDK wallet to the main bank balance.                                                                        | Cannot withdraw from subaccount 0.                                                           |