### PR TITLE
fix: lock around sending transactions

### DIFF
--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -114,7 +114,7 @@ class InjectiveChain:
       signed = wallet.sign(transaction)
 
       logger.debug(
-        "Calling Injective chain to send sync transaction with messages=%s account=%s sequence=%d chain_id=%s gas=%d fee=%d",
+        "Calling Injective chain to send sync transaction with messages=%s account=%s seq=%d chain_id=%s gas=%d fee=%d",
         str(messages),
         wallet.account_number,
         wallet.sequence,

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -1,7 +1,9 @@
 import asyncio
 import logging
 
+from asyncio import Lock
 from collections import defaultdict
+from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import Set
@@ -32,7 +34,7 @@ logger = logging.getLogger(__name__)
 
 class InjectiveChain:
 
-  LOCKS = defaultdict(asyncio.Lock)
+  LOCKS: Dict[str, Lock] = defaultdict(Lock)
 
   # TODO these are made up numbers
   GAS_PRICE = 500_000_000

--- a/frontrunner_sdk/clients/injective_chain.py
+++ b/frontrunner_sdk/clients/injective_chain.py
@@ -101,43 +101,43 @@ class InjectiveChain:
     gas: int,
     fee: List[Coin],
   ) -> TxResponse:
-    async with self.LOCKS[wallet.injective_address]:
-      transaction = Transaction(
-        msgs=messages,
-        sequence=wallet.sequence,
-        account_num=wallet.account_number,
-        chain_id=self.network.chain_id,
-        gas=gas,
-        fee=fee,
-      )
+    transaction = Transaction(
+      msgs=messages,
+      sequence=wallet.sequence,
+      account_num=wallet.account_number,
+      chain_id=self.network.chain_id,
+      gas=gas,
+      fee=fee,
+    )
 
-      signed = wallet.sign(transaction)
+    signed = wallet.sign(transaction)
 
-      logger.debug(
-        "Calling Injective chain to send sync transaction with messages=%s account=%s seq=%d chain_id=%s gas=%d fee=%d",
-        str(messages),
-        wallet.account_number,
-        wallet.sequence,
-        self.network.chain_id,
-        gas,
-        fee,
-      )
+    logger.debug(
+      "Calling Injective chain to send sync transaction with messages=%s account=%s seq=%d chain_id=%s gas=%d fee=%d",
+      str(messages),
+      wallet.account_number,
+      wallet.sequence,
+      self.network.chain_id,
+      gas,
+      fee,
+    )
 
-      response = await self.client.send_tx_sync_mode(signed)
+    response = await self.client.send_tx_sync_mode(signed)
 
-      logger.debug("Received transaction response from Injective chain yielding response=%s", response)
+    logger.debug("Received transaction response from Injective chain yielding response=%s", response)
 
-      if response.code > 0:
-        raise FrontrunnerInjectiveException("Transaction failed", message=response.raw_log)
+    if response.code > 0:
+      raise FrontrunnerInjectiveException("Transaction failed", message=response.raw_log)
 
-      else:
-        wallet.get_and_increment_sequence()
+    else:
+      wallet.get_and_increment_sequence()
 
-      return response
+    return response
 
   async def _execute_transaction(self, wallet: Wallet, messages: List[Message]) -> TxResponse:
-    gas, fee = await self._estimate_cost(messages)
-    return await self._send_transaction(wallet, messages, gas, fee)
+    async with self.LOCKS[wallet.injective_address]:
+      gas, fee = await self._estimate_cost(messages)
+      return await self._send_transaction(wallet, messages, gas, fee)
 
   @log_external_exceptions(__name__)
   async def get_all_open_orders(self, subaccount: Subaccount) -> Iterable[DerivativeLimitOrder]:

--- a/tests/clients/test_injective_chain.py
+++ b/tests/clients/test_injective_chain.py
@@ -1,6 +1,9 @@
+import asyncio
+
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from pyinjective.async_client import AsyncClient
 from pyinjective.composer import Composer
@@ -114,6 +117,34 @@ class TestInjectiveChain(IsolatedAsyncioTestCase):
     with self.assertRaises(FrontrunnerInjectiveException):
       await self.injective_chain._send_transaction(self.wallet, [self.order], 100, [])
       self.assertEqual(0, self.wallet.sequence)
+
+  @patch.object(InjectiveChain, "_estimate_cost", new_callable=AsyncMock, return_value=(0, []))
+  async def test_execute_transaction_concurrent(self, _estimate_cost):
+    # This asserts that within _execute_transaction, there is no interleaving such that multiple of the same sequence
+    # number are used for transactions. This is possible when:
+    #
+    # * there are `await`s between tx create and sequence update
+    # * the awaits are "slow" enough such that Python interleaves their execution
+    # * there are multiple `_execute_transaction` coroutines happening simultaneously
+
+    async def delayed_tx_response(*args, **kwargs):
+      # simulated delay to force interleaving between `await`s in asyncio.gather
+      await asyncio.sleep(0.01)
+      return TxResponse(code=0)
+
+    self.client.send_tx_sync_mode = AsyncMock(side_effect=delayed_tx_response)
+
+    sequence_ids = []
+
+    # there's no good way to inspect the sequence ids used, so we'll just intercept and record instead
+    with patch.object(Wallet, "sign", side_effect=lambda tx: sequence_ids.append(tx.sequence)):
+      # multiple coroutines in asyncio.gather allows for the interleaving to happen
+      await asyncio.gather(*[self.injective_chain._execute_transaction(self.wallet, [self.order]) for _ in range(10)])
+
+    self.assertEqual(
+      set(sequence_ids),
+      set(range(10)),
+    )
 
   async def test_execute_transaction(self):
     expected = MagicMock(spec=TxResponse)

--- a/tests/clients/test_injective_chain.py
+++ b/tests/clients/test_injective_chain.py
@@ -142,8 +142,8 @@ class TestInjectiveChain(IsolatedAsyncioTestCase):
       await asyncio.gather(*[self.injective_chain._execute_transaction(self.wallet, [self.order]) for _ in range(10)])
 
     self.assertEqual(
-      set(sequence_ids),
-      set(range(10)),
+      sorted(sequence_ids),
+      list(range(10)),
     )
 
   async def test_execute_transaction(self):


### PR DESCRIPTION
Sending transactions must be single line of execution because it depends on a monotonically increasing sequence value. Without the lock, any use of `asyncio.gather` on 2+ transactions will cause at least one to fail.

# Testing

If I remove the lock line `async with self.LOCKS[wallet.injective_address]:` and rerun the test, I get...

```
E     AssertionError: Lists differ: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] != [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
E     
E     First differing element 1:
E     0
E     1
E     
E     - [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
E     + [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
```

When I leave the lock in, the test passes.