### PR TITLE
feat: add wallet refresh operation

### DIFF
--- a/docs/includes/operations/injective/_refresh_wallet.md
+++ b/docs/includes/operations/injective/_refresh_wallet.md
@@ -1,0 +1,23 @@
+## Injective: Refresh Wallet
+
+Refreshes the wallet.
+
+Transactions require a monotonically increasing sequence ID. This sequence ID is tracked internally in the wallet. If the sequence ID known in the wallet drifts for any reason, refreshing the wallet will update the wallet with the latest sequence ID.
+
+### Parameters
+
+None.
+
+```python
+response = sdk.injective.refresh_wallet()
+```
+
+### Response
+
+```python
+print("wallet sequence:", response.wallet.sequence)
+```
+
+| Name | Type | Description |
+| - | - | - |
+| `wallet` | `Wallet` | The internal wallet, same instance as `sdk.wallet()` |

--- a/docs/index.html.md
+++ b/docs/index.html.md
@@ -37,6 +37,7 @@ includes:
   - operations/injective/get_positions
   - operations/injective/get_trades
   - operations/injective/get_transaction
+  - operations/injective/refresh_wallet
   - operations/injective/stream_markets
   - operations/injective/stream_orders
   - operations/injective/stream_positions

--- a/frontrunner_sdk/commands/injective/refresh_wallet.py
+++ b/frontrunner_sdk/commands/injective/refresh_wallet.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+from frontrunner_sdk.commands.base import FrontrunnerOperation
+from frontrunner_sdk.ioc import FrontrunnerIoC
+from frontrunner_sdk.logging.log_operation import log_operation
+from frontrunner_sdk.models.wallet import Wallet
+
+
+@dataclass
+class RefreshWalletRequest:
+  pass
+
+
+@dataclass
+class RefreshWalletResponse:
+  wallet: Wallet
+
+
+class RefreshWalletOperation(FrontrunnerOperation[RefreshWalletRequest, RefreshWalletResponse]):
+
+  def __init__(self, request: RefreshWalletRequest):
+    super().__init__(request)
+
+  def validate(self, deps: FrontrunnerIoC) -> None:
+    pass
+
+  @log_operation(__name__)
+  async def execute(self, deps: FrontrunnerIoC) -> RefreshWalletResponse:
+    wallet = await deps.wallet()
+
+    await deps.injective_light_client_daemon.initialize_wallet(wallet)
+
+    return RefreshWalletResponse(wallet=wallet)

--- a/frontrunner_sdk/facades/injective.py
+++ b/frontrunner_sdk/facades/injective.py
@@ -46,7 +46,8 @@ from frontrunner_sdk.commands.injective.get_trades import GetTradesResponse
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionOperation # NOQA
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionRequest # NOQA
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionResponse # NOQA
-from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletOperation, RefreshWalletRequest # NOQA
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletOperation # NOQA
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletRequest # NOQA
 from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletResponse # NOQA
 from frontrunner_sdk.commands.injective.stream_markets import StreamMarketsOperation # NOQA
 from frontrunner_sdk.commands.injective.stream_markets import StreamMarketsRequest # NOQA

--- a/frontrunner_sdk/facades/injective.py
+++ b/frontrunner_sdk/facades/injective.py
@@ -46,6 +46,8 @@ from frontrunner_sdk.commands.injective.get_trades import GetTradesResponse
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionOperation # NOQA
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionRequest # NOQA
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionResponse # NOQA
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletOperation, RefreshWalletRequest # NOQA
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletResponse # NOQA
 from frontrunner_sdk.commands.injective.stream_markets import StreamMarketsOperation # NOQA
 from frontrunner_sdk.commands.injective.stream_markets import StreamMarketsRequest # NOQA
 from frontrunner_sdk.commands.injective.stream_markets import StreamMarketsResponse # NOQA
@@ -81,6 +83,10 @@ class InjectiveFacadeAsync(FrontrunnerFacadeMixin):
   async def create_wallet(self, fund_and_initialize: bool = True) -> CreateWalletResponse:
     request = CreateWalletRequest(fund_and_initialize=fund_and_initialize)
     return await self._run_operation(CreateWalletOperation, self.deps, request)
+
+  async def refresh_wallet(self) -> RefreshWalletResponse:
+    request = RefreshWalletRequest()
+    return await self._run_operation(RefreshWalletOperation, self.deps, request)
 
   async def fund_external_wallet(
     self,
@@ -258,8 +264,11 @@ class InjectiveFacade(SyncMixin):
   def __init__(self, deps: FrontrunnerIoC):
     self.impl = InjectiveFacadeAsync(deps)
 
-  def create_wallet(self) -> CreateWalletResponse:
-    return self._synchronously(self.impl.create_wallet)
+  def create_wallet(self, fund_and_initialize: bool = True) -> CreateWalletResponse:
+    return self._synchronously(self.impl.create_wallet, fund_and_initialize)
+
+  def refresh_wallet(self) -> RefreshWalletResponse:
+    return self._synchronously(self.impl.refresh_wallet)
 
   def fund_external_wallet(
     self,

--- a/tests/commands/injective/test_refresh_wallet.py
+++ b/tests/commands/injective/test_refresh_wallet.py
@@ -1,0 +1,27 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletRequest # NOQA
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletOperation # NOQA
+from frontrunner_sdk.ioc import FrontrunnerIoC
+from frontrunner_sdk.models.wallet import Wallet
+
+
+class TestCreateWalletOperation(IsolatedAsyncioTestCase):
+
+  def setUp(self) -> None:
+    self.wallet = Wallet._new()
+
+    self.deps = MagicMock(spec=FrontrunnerIoC)
+    self.deps.wallet = AsyncMock(return_value=self.wallet)
+
+    self.deps.injective_light_client_daemon.initialize_wallet = AsyncMock()
+
+  async def test_refresh_wallet(self):
+    req = RefreshWalletRequest()
+    cmd = RefreshWalletOperation(req)
+    res = await cmd.execute(self.deps)
+
+    self.deps.injective_light_client_daemon.initialize_wallet.assert_awaited_once_with(self.wallet)
+
+    self.assertIs(res.wallet, self.wallet)

--- a/tests/commands/injective/test_refresh_wallet.py
+++ b/tests/commands/injective/test_refresh_wallet.py
@@ -1,8 +1,9 @@
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
-from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletRequest # NOQA
 from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletOperation # NOQA
+from frontrunner_sdk.commands.injective.refresh_wallet import RefreshWalletRequest # NOQA
 from frontrunner_sdk.ioc import FrontrunnerIoC
 from frontrunner_sdk.models.wallet import Wallet
 


### PR DESCRIPTION
Adds an escape hatch if the sequence drifts.

# Testing

```
In [1]: from frontrunner_sdk import FrontrunnerSDK

In [2]: sdk = FrontrunnerSDK()

In [3]: refresh_wallet = sdk.injective.refresh_wallet()

In [4]: refresh_wallet.wallet == sdk.wallet()
Out[4]: True

In [5]: refresh_wallet.wallet.sequence
Out[5]: 69

In [6]: refresh_wallet.wallet is sdk.wallet()
Out[6]: True
```