### PR TITLE
chore: increase gas offset 20k → 80k

### DIFF
--- a/frontrunner_sdk/clients/gas_estimators/offsetting_gas_estimator.py
+++ b/frontrunner_sdk/clients/gas_estimators/offsetting_gas_estimator.py
@@ -5,7 +5,7 @@ from frontrunner_sdk.clients.gas_estimators.gas_estimator import GasEstimator
 
 class OffsettingGasEstimator(GasEstimator):
 
-  GAS_OFFSET = 20_000
+  GAS_OFFSET = 80_000
 
   def __init__(self, estimator: GasEstimator):
     self.estimator = estimator

--- a/frontrunner_sdk/clients/gas_estimators/table_gas_estimator.py
+++ b/frontrunner_sdk/clients/gas_estimators/table_gas_estimator.py
@@ -26,7 +26,7 @@ class TableGasEstimator(GasEstimator):
 
     if message_type not in self.MESSAGE_RATES:
       raise FrontrunnerInjectiveException(
-        "Fee not available for message type",
+        "Gas not available for message type",
         message_type=message_type,
       )
 
@@ -42,7 +42,7 @@ class TableGasEstimator(GasEstimator):
 
         if order_type not in self.ORDER_RATES:
           raise FrontrunnerInjectiveException(
-            "Fee not available for order type",
+            "Gas not available for order type",
             message_type=message_type,
             order_type=descriptor.message_type.name,
           )


### PR DESCRIPTION
We're seeing occasional failures when the offset is at 20k, assuming the other base gas rates are correct. Injective mentioned their current market makers use 80k - 100k buffers.

# Testing

```
import random

from frontrunner_sdk import FrontrunnerSDK
from frontrunner_sdk.models import Order

sdk = FrontrunnerSDK()

find_markets = sdk.frontrunner.find_markets(
  sports=["baseball"],
  event_types=["future"],
  prop_types=["winner"],
  market_statuses=["active"],
)

market_id = random.sample(find_markets.market_ids, 1)[0]

orders = [
  Order.buy_long(market_id, 10, 0.01, subaccount_index=1),
  Order.buy_short(market_id, 10, 0.01, subaccount_index=2),
]

create_orders = sdk.injective.create_orders(orders)

print("transaction:", create_orders.transaction)
```

Ran this twice

* https://testnet.explorer.injective.network/transaction/FD052C13C9703B8D5FFF9969437C0BC018EFDD3C77AE4127CCEB0F34C4C3E911/
* https://testnet.explorer.injective.network/transaction/5FF058DD6C7B0099308F1AD5E84A74A0F3DB564842FF425C76A46B9699E3CC7E/

Both transactions succeeded.

* Gas (Used/Requested) 96,504 / 156,424
* Gas (Used/Requested) 95,385 / 156,424