### PR TITLE
feat: include local order hashes, allow order hash correlation

### DIFF
--- a/docs/includes/operations/injective/_create_orders.md
+++ b/docs/includes/operations/injective/_create_orders.md
@@ -43,8 +43,18 @@ See <a href="https://testnet.explorer.injective.network/transaction/BAE72A64BE09
 
 ```python
 print("transaction:", response.transaction)
+
+for order in response.orders:
+  print(
+    "order:",
+    order.market_id,
+    "for", order.quantity, "@" order.price,
+    "in subaccount", order.subaccount_index,
+    "with hash", order.hash,
+  )
 ```
 
 | Name | Type | Description |
 | - | - | - |
 | `transaction` | `str` | Transaction ID of the order creation |
+| `orders` | `List[Order]` | Orders from input, but with `hash` defined |

--- a/frontrunner_sdk/clients/injective_order_hasher.py
+++ b/frontrunner_sdk/clients/injective_order_hasher.py
@@ -1,6 +1,7 @@
 from typing import Awaitable
 from typing import Callable
 from typing import Dict
+from typing import Optional
 from typing import Tuple
 
 from pyinjective.constant import Network
@@ -26,6 +27,14 @@ class InjectiveOrderHasher:
       )
 
     return self.hashers[wallet.injective_address, subaccount_index]
+
+  async def reset(self, subaccount_index: Optional[int] = None) -> None:
+    if subaccount_index is None:
+      self.hashers.clear()
+
+    else:
+      wallet = await self.wallet_fn()
+      del self.hashers[wallet.injective_address, subaccount_index]
 
   async def hash(self, order: DerivativeOrder, subaccount_index: int) -> str:
     wallet = await self.wallet_fn()

--- a/frontrunner_sdk/clients/injective_order_hasher.py
+++ b/frontrunner_sdk/clients/injective_order_hasher.py
@@ -1,0 +1,37 @@
+from typing import Awaitable
+from typing import Callable
+from typing import Dict
+from typing import Tuple
+
+from pyinjective.constant import Network
+from pyinjective.orderhash import OrderHashManager
+from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import DerivativeOrder # NOQA
+
+from frontrunner_sdk.models.wallet import Wallet
+
+
+class InjectiveOrderHasher:
+
+  def __init__(self, network: Network, wallet_fn: Callable[[], Awaitable[Wallet]]):
+    self.network = network
+    self.wallet_fn = wallet_fn
+    self.hashers: Dict[Tuple[str, int], OrderHashManager] = {}
+
+  def _hasher_for(self, wallet: Wallet, subaccount_index: int) -> OrderHashManager:
+    if (wallet.injective_address, subaccount_index) not in self.hashers:
+      self.hashers[wallet.injective_address, subaccount_index] = OrderHashManager(
+        address=wallet.address,
+        network=self.network,
+        subaccount_indexes=[subaccount_index],
+      )
+
+    return self.hashers[wallet.injective_address, subaccount_index]
+
+  async def hash(self, order: DerivativeOrder, subaccount_index: int) -> str:
+    wallet = await self.wallet_fn()
+
+    hasher = self._hasher_for(wallet, subaccount_index)
+
+    response = hasher.compute_order_hashes([], [order], subaccount_index)
+
+    return response.derivative[0]

--- a/frontrunner_sdk/helpers/encoders.py
+++ b/frontrunner_sdk/helpers/encoders.py
@@ -1,0 +1,9 @@
+import base64
+
+
+def b64_to_hex(b64_value: str) -> str:
+  return base64.b64decode(b64_value.encode("utf-8")).hex()
+
+
+def hex_to_b64(hex_value: str) -> str:
+  return str(base64.b64encode(bytes.fromhex(hex_value)), "utf-8")

--- a/frontrunner_sdk/ioc.py
+++ b/frontrunner_sdk/ioc.py
@@ -14,6 +14,7 @@ from frontrunner_sdk.clients.gas_estimators.table_gas_estimator import TableGasE
 from frontrunner_sdk.clients.injective_chain import InjectiveChain
 from frontrunner_sdk.clients.injective_faucet import InjectiveFaucet
 from frontrunner_sdk.clients.injective_light_client_daemon import InjectiveLightClientDaemon # NOQA
+from frontrunner_sdk.clients.injective_order_hasher import InjectiveOrderHasher # NOQA
 from frontrunner_sdk.clients.openapi_client import openapi_client # NOQA
 from frontrunner_sdk.config import DEFAULT
 from frontrunner_sdk.config.base import FrontrunnerConfig
@@ -106,8 +107,15 @@ class FrontrunnerIoC(SyncMixin):
     return InjectiveLightClientDaemon(self.config.injective_lcd_base_url)
 
   @cached_property
+  def injective_order_hasher(self) -> InjectiveOrderHasher:
+    return InjectiveOrderHasher(self.network, self.wallet)
+
+  @cached_property
   def injective_chain(self) -> InjectiveChain:
-    return InjectiveChain(self.injective_composer, self.injective_client, self.network, self.injective_gas_estimator)
+    return InjectiveChain(
+      self.injective_composer, self.injective_client, self.network, self.injective_order_hasher,
+      self.injective_gas_estimator
+    )
 
   @cached_property
   def injective_faucet(self) -> InjectiveFaucet:

--- a/frontrunner_sdk/models/order.py
+++ b/frontrunner_sdk/models/order.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import AsyncIterator
 from typing import Literal
+from typing import Optional
 from typing import Sequence
 from typing import Type
 from typing import TypeVar
@@ -80,7 +81,7 @@ class OrderHistory:
       yield cls(injective_order.order)
 
 
-@dataclass
+@dataclass(frozen=True)
 class Order:
   direction: Literal["buy", "sell"]
   side: Literal["long", "short"]
@@ -89,6 +90,7 @@ class Order:
   price: float
   subaccount_index: int
   is_post_only: bool
+  hash: Optional[str] = None
 
   @classmethod
   def buy_long(
@@ -113,3 +115,15 @@ class Order:
     clz, market_id: str, quantity: int, price: float, subaccount_index: int = 0, is_post_only: bool = False
   ) -> "Order":
     return clz("sell", "short", market_id, quantity, price, subaccount_index, is_post_only)
+
+  def with_hash(self, hash: str) -> "Order":
+    return Order(
+      direction=self.direction,
+      side=self.side,
+      market_id=self.market_id,
+      quantity=self.quantity,
+      price=self.price,
+      subaccount_index=self.subaccount_index,
+      is_post_only=self.is_post_only,
+      hash=hash,
+    )

--- a/tests/clients/test_injective_order_hasher.py
+++ b/tests/clients/test_injective_order_hasher.py
@@ -1,0 +1,88 @@
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import DerivativeOrder # NOQA
+from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import OrderInfo
+from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import OrderType
+
+from frontrunner_sdk.clients.injective_order_hasher import InjectiveOrderHasher
+from frontrunner_sdk.models.wallet import Wallet
+
+
+class TestInjectiveOrderHasher(IsolatedAsyncioTestCase):
+
+  def setUp(self):
+    self.wallet = Wallet._new()
+    self.network = MagicMock(lcd_endpoint="http://lcd.endpoint")
+    self.wallet_fn = AsyncMock(return_value=self.wallet)
+    self.order_hasher = InjectiveOrderHasher(self.network, self.wallet_fn)
+
+  @patch("requests.get", return_value=MagicMock(json=MagicMock(return_value={"nonce": 0})))
+  def test_hasher_for(self, _get):
+    hasher = self.order_hasher._hasher_for(self.wallet, 0)
+
+    cached = self.order_hasher._hasher_for(self.wallet, 0)
+
+    _get.assert_called_once_with(
+      url="http://lcd.endpoint/injective/exchange/v1beta1/exchange/" + self.wallet.subaccount_address(0)
+    )
+
+    self.assertIs(hasher, cached)
+
+  @patch("requests.get", return_value=MagicMock(json=MagicMock(return_value={"nonce": 0})))
+  async def test_reset_all(self, _get):
+    hasher = self.order_hasher._hasher_for(self.wallet, 0)
+
+    await self.order_hasher.reset()
+
+    cached = self.order_hasher._hasher_for(self.wallet, 0)
+
+    _get.assert_has_calls([
+      call(url="http://lcd.endpoint/injective/exchange/v1beta1/exchange/" + self.wallet.subaccount_address(0)),
+      call(url="http://lcd.endpoint/injective/exchange/v1beta1/exchange/" + self.wallet.subaccount_address(0)),
+    ])
+
+    self.assertIsNot(hasher, cached)
+
+  @patch("requests.get", return_value=MagicMock(json=MagicMock(return_value={"nonce": 0})))
+  async def test_reset_one(self, _get):
+    hasher = self.order_hasher._hasher_for(self.wallet, 0)
+    other = self.order_hasher._hasher_for(self.wallet, 1)
+
+    await self.order_hasher.reset(0)
+
+    hasher_cached = self.order_hasher._hasher_for(self.wallet, 0)
+    other_cached = self.order_hasher._hasher_for(self.wallet, 1)
+
+    self.assertIsNot(hasher, hasher_cached)
+    self.assertIs(other, other_cached)
+
+  @patch("requests.get", return_value=MagicMock(json=MagicMock(return_value={"nonce": 0})))
+  async def test_hash(self, _get):
+    order = DerivativeOrder(
+      market_id="<market-id>",
+      order_info=OrderInfo(
+        subaccount_id=self.wallet.subaccount_address(),
+        fee_recipient=self.wallet.subaccount_address(),
+        price="500000",
+        quantity="100",
+      ),
+      margin="500000",
+      order_type=OrderType.BUY,
+      trigger_price="500000",
+    )
+
+    order_hash = await self.order_hasher.hash(order, 0)
+
+    await self.order_hasher.reset()
+
+    order_rehash = await self.order_hasher.hash(order, 0)
+
+    self.assertEqual(order_hash, order_rehash)
+
+    order_again = await self.order_hasher.hash(order, 0)
+
+    self.assertNotEqual(order_hash, order_again)

--- a/tests/commands/injective/test_get_transaction.py
+++ b/tests/commands/injective/test_get_transaction.py
@@ -9,7 +9,7 @@ from frontrunner_sdk import FrontrunnerIoC
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionOperation # NOQA
 from frontrunner_sdk.commands.injective.get_transaction import GetTransactionRequest # NOQA
 from frontrunner_sdk.commands.injective.get_transaction import OrderFailure
-from frontrunner_sdk.exceptions import FrontrunnerArgumentException # NOQA
+from frontrunner_sdk.helpers.encoders import b64_to_hex
 
 
 class TestGetTransactionOperation(IsolatedAsyncioTestCase):
@@ -17,7 +17,8 @@ class TestGetTransactionOperation(IsolatedAsyncioTestCase):
   def setUp(self) -> None:
     self.deps = MagicMock(spec=FrontrunnerIoC)
     self.flags = [59]
-    self.hashes = ["3LVlH0iM5ZvkrZd9yCOZP5F3bgSEjPm7oPEkkOl7ank="]
+    self.b64_hashes = ["3LVlH0iM5ZvkrZd9yCOZP5F3bgSEjPm7oPEkkOl7ank="]
+    self.hashes = ["0x" + b64_to_hex(h) for h in self.b64_hashes]
 
   def test_validate(self):
     req = GetTransactionRequest(transaction_hash="abc")
@@ -27,7 +28,7 @@ class TestGetTransactionOperation(IsolatedAsyncioTestCase):
   async def test_get_transaction_order_failures(self):
     mock_attributes = [
       Mock(key="flags", value=json.dumps(self.flags)),
-      Mock(key="hashes", value=json.dumps(self.hashes))
+      Mock(key="hashes", value=json.dumps(self.b64_hashes))
     ]
     mock_log = Mock(events=[Mock(type="injective.exchange.v1beta1.EventOrderFail", attributes=mock_attributes)])
     mock_response = mock_tx_response = Mock()

--- a/tests/facades/test_injective.py
+++ b/tests/facades/test_injective.py
@@ -76,7 +76,7 @@ class TestInjectiveFacadeAsync(IsolatedAsyncioTestCase):
     CreateOrdersOperation,
     "execute",
     new_callable=AsyncMock,
-    return_value=CreateOrdersResponse(transaction="<hash>"),
+    return_value=CreateOrdersResponse(transaction="<hash>", orders=[]),
   )
   async def test_create_orders(self, _execute: AsyncMock):
     await self.facade.create_orders([Order.buy_short("<marketid>", 10, 0.7)])

--- a/tests/helpers/test_encoders.py
+++ b/tests/helpers/test_encoders.py
@@ -1,0 +1,18 @@
+from unittest import TestCase
+
+from frontrunner_sdk.helpers.encoders import b64_to_hex, hex_to_b64
+
+
+class TestEncoders(TestCase):
+
+  def test_b64_to_hex(self):
+    self.assertEqual(
+      "b2195542938e1b2f8601df0509b8e56b1c7b2f049e6efb996e799cffa2d5e517",
+      b64_to_hex("shlVQpOOGy+GAd8FCbjlaxx7LwSebvuZbnmc/6LV5Rc="),
+    )
+
+  def test_hex_to_b64(self):
+    self.assertEqual(
+      "shlVQpOOGy+GAd8FCbjlaxx7LwSebvuZbnmc/6LV5Rc=",
+      hex_to_b64("b2195542938e1b2f8601df0509b8e56b1c7b2f049e6efb996e799cffa2d5e517"),
+    )

--- a/tests/helpers/test_encoders.py
+++ b/tests/helpers/test_encoders.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
-from frontrunner_sdk.helpers.encoders import b64_to_hex, hex_to_b64
+from frontrunner_sdk.helpers.encoders import b64_to_hex
+from frontrunner_sdk.helpers.encoders import hex_to_b64
 
 
 class TestEncoders(TestCase):

--- a/tests/test_ioc.py
+++ b/tests/test_ioc.py
@@ -3,9 +3,11 @@ from unittest.mock import AsyncMock
 from unittest.mock import patch
 
 from frontrunner_sdk.clients.denom_factory import DenomFactory
+from frontrunner_sdk.clients.gas_estimators.gas_estimator import GasEstimator
 from frontrunner_sdk.clients.injective_chain import InjectiveChain
 from frontrunner_sdk.clients.injective_faucet import InjectiveFaucet
 from frontrunner_sdk.clients.injective_light_client_daemon import InjectiveLightClientDaemon # NOQA
+from frontrunner_sdk.clients.injective_order_hasher import InjectiveOrderHasher # NOQA
 from frontrunner_sdk.config import DEFAULT # NOQA
 from frontrunner_sdk.config.base import FrontrunnerConfig
 from frontrunner_sdk.config.static import StaticFrontrunnerConfig
@@ -81,11 +83,21 @@ class TestFrontrunnerIoC(IsolatedAsyncioTestCase):
     self.assertIsInstance(ioc.injective_chain, InjectiveChain)
 
   def test_injective_faucet(self):
-    ioc = self.ioc_for(injective_faucet_base_url="https://faucet.injective.example",)
+    ioc = self.ioc_for(injective_faucet_base_url="https://faucet.injective.example")
 
     self.assertIsInstance(ioc.injective_faucet, InjectiveFaucet)
 
   def test_injective_light_client_daemon(self):
-    ioc = self.ioc_for(injective_lcd_base_url="https://lcd.injective.example",)
+    ioc = self.ioc_for(injective_lcd_base_url="https://lcd.injective.example")
 
     self.assertIsInstance(ioc.injective_light_client_daemon, InjectiveLightClientDaemon)
+
+  def test_injective_gas_estimator(self):
+    ioc = self.ioc_for()
+
+    self.assertIsInstance(ioc.injective_gas_estimator, GasEstimator)
+
+  def test_injective_order_hasher(self):
+    ioc = self.ioc_for(injective_network="mainnet")
+
+    self.assertIsInstance(ioc.injective_order_hasher, InjectiveOrderHasher)


### PR DESCRIPTION
This adds locally-computed order hashes so that devs can detect _which_ order in a transaction failed, if any.

Even if a transaction succeeds, some orders within may fail. When retrieving the transaction, the "failed" orders are expressed as a hash. The hash can only be retrieved (for failed transactions) by local computation. It's non-trivial to get these, so it's easies to return them alongside order creation. Then, on `get_transaction`, you can see which order(s) failed by seeing which order's hashes are in the `get_transaction` hashes.

# Testing

```python
import random
import time

from frontrunner_sdk import FrontrunnerSDK
from frontrunner_sdk.models import Order

sdk = FrontrunnerSDK()

find_markets = sdk.frontrunner.find_markets(
  sports=["baseball"],
  event_types=["game"],
  prop_types=["winner"],
  market_statuses=["active"],
)

orders = [Order.buy_long(market_id, 10, 0.01) for market_id in random.sample(find_markets.market_ids, 2)]

create_orders = sdk.injective.create_orders(orders)

print("transaction:", create_orders.transaction)

for order in create_orders.orders:
  print("order:", order.quantity, "@", order.price, "#", order.hash)

get_transaction = sdk.injective.get_transaction(create_orders.transaction)

for order_failure in get_transaction.order_failures:
  for flag, order_hash in zip(order_failure.flags, order_failure.hashes):
    print("failure:", flag, order_hash)
```

```
transaction: 9C55ADDF1C563106F4AF68F67190E80B1777BFA04695A3D814FADA06889E1C5F
order: 10 @ 0.01 # 0xf1fb23d69d9339a0eccfaa613b7ad16728d4adc049e78175110af8329b43bf7b
order: 10 @ 0.01 # 0x3b17d948a81d4de8a6be6a23edde76edcf5341ce6be26c3f72559db1b5083c51

failure: 95 0xf1fb23d69d9339a0eccfaa613b7ad16728d4adc049e78175110af8329b43bf7b
failure: 95 0x3b17d948a81d4de8a6be6a23edde76edcf5341ce6be26c3f72559db1b5083c51
```

https://testnet.explorer.injective.network/transaction/9C55ADDF1C563106F4AF68F67190E80B1777BFA04695A3D814FADA06889E1C5F/
