### PR TITLE
chore: temporarily remove Frontrunner mainnet node config option

### DIFF
--- a/docs/includes/_configuring.md
+++ b/docs/includes/_configuring.md
@@ -116,11 +116,11 @@ Frontrunner does not run the Injective Explorer, so Explorer Authority defaults 
 
 | Endpoint Type | Default Value |
 | - | - |
-| Exchange Authority | `injective-node-mainnet.grpc-exchange.getfrontrunner.com:443` |
+| Exchange Authority | `k8s.global.mainnet.exchange.grpc.injective.network:443` |
 | Explorer Authority | `k8s.global.mainnet.explorer.grpc.injective.network:443` |
-| LCD Base URL | `https://injective-node-mainnet.lcd.getfrontrunner.com` |
-| RPC Base URL | `wss://injective-node-mainnet.tm.getfrontrunner.com/websocket` |
-| gRPC Authority | `injective-node-mainnet.grpc.getfrontrunner.com:443` |
+| LCD Base URL | `https://k8s.global.mainnet.lcd.injective.network:44` |
+| RPC Base URL | `wss://k8s.global.mainnet.tm.injective.network:443/websocket` |
+| gRPC Authority | `k8s.global.mainnet.chain.grpc.injective.network:443` |
 
 ### Presets
 

--- a/frontrunner_sdk/config/__init__.py
+++ b/frontrunner_sdk/config/__init__.py
@@ -18,8 +18,9 @@ def fr_injective_network():
 
 
 def should_use_node_set(injective_network: str, endpoint_set_identifier: str):
+  default_preset = "frontrunner" if injective_network == "testnet" else "injective-global"
   return fr_injective_network() == injective_network and \
-    os.environ.get("FR_PRESET_NODES", "frontrunner") == endpoint_set_identifier
+    os.environ.get("FR_PRESET_NODES", default_preset) == endpoint_set_identifier
 
 
 DEFAULT: FrontrunnerConfig = ChainedFrontrunnerConfig([
@@ -52,6 +53,8 @@ DEFAULT: FrontrunnerConfig = ChainedFrontrunnerConfig([
       injective_insecure=True,
     )
   ),
+
+  # default mainnet config
   ConditionalFrontrunnerConfig(
     lambda: should_use_node_set("mainnet", "injective-global"),
     StaticFrontrunnerConfig(
@@ -60,19 +63,6 @@ DEFAULT: FrontrunnerConfig = ChainedFrontrunnerConfig([
       injective_grpc_authority=injective_mainnet_global_network.grpc_endpoint,
       injective_lcd_base_url=injective_mainnet_global_network.lcd_endpoint,
       injective_rpc_base_url=injective_mainnet_global_network.tm_websocket_endpoint,
-    )
-  ),
-
-  # default mainnet config
-  ConditionalFrontrunnerConfig(
-    lambda: should_use_node_set("mainnet", "frontrunner"),
-    StaticFrontrunnerConfig(
-      injective_exchange_authority="injective-node-mainnet.grpc-exchange.getfrontrunner.com:443",
-      # Frontrunner doesn't run the explorer, so use Injective's endpoint regardless
-      injective_explorer_authority=injective_mainnet_global_network.grpc_explorer_endpoint,
-      injective_grpc_authority="injective-node-mainnet.grpc.getfrontrunner.com:443",
-      injective_lcd_base_url="https://injective-node-mainnet.lcd.getfrontrunner.com",
-      injective_rpc_base_url="wss://injective-node-mainnet.tm.getfrontrunner.com/websocket",
     )
   ),
   ConditionalFrontrunnerConfig(

--- a/tests/config/test_configs.py
+++ b/tests/config/test_configs.py
@@ -42,12 +42,10 @@ class TestFrontrunnerConfig(TestCase):
     self.assertEqual("mainnet", DEFAULT.injective_network)
     self.assertEqual("injective-1", DEFAULT.injective_chain_id)
     self.assertEqual(False, DEFAULT.injective_insecure)
-    self.assertEqual(
-      "injective-node-mainnet.grpc-exchange.getfrontrunner.com:443", DEFAULT.injective_exchange_authority
-    )
-    self.assertEqual("injective-node-mainnet.grpc.getfrontrunner.com:443", DEFAULT.injective_grpc_authority)
-    self.assertEqual("https://injective-node-mainnet.lcd.getfrontrunner.com", DEFAULT.injective_lcd_base_url)
-    self.assertEqual("wss://injective-node-mainnet.tm.getfrontrunner.com/websocket", DEFAULT.injective_rpc_base_url)
+    self.assertEqual("k8s.global.mainnet.exchange.grpc.injective.network:443", DEFAULT.injective_exchange_authority)
+    self.assertEqual("k8s.global.mainnet.chain.grpc.injective.network:443", DEFAULT.injective_grpc_authority)
+    self.assertEqual("https://k8s.global.mainnet.lcd.injective.network:443", DEFAULT.injective_lcd_base_url)
+    self.assertEqual("wss://k8s.global.mainnet.tm.injective.network:443/websocket", DEFAULT.injective_rpc_base_url)
     self.assertEqual("k8s.global.mainnet.explorer.grpc.injective.network:443", DEFAULT.injective_explorer_authority)
     self.assertEqual("https://partner-api-mainnet.getfrontrunner.com/api/v1", DEFAULT.partner_api_base_url)
 


### PR DESCRIPTION
Mainnet node isn't live yet, so removing for now