### PR TITLE
feat: add new MultiplierTableGasEstimator for increased gas estimation

### DIFF
--- a/frontrunner_sdk/clients/gas_estimators/multiplier_table_gas_estimator.py
+++ b/frontrunner_sdk/clients/gas_estimators/multiplier_table_gas_estimator.py
@@ -1,0 +1,15 @@
+from google.protobuf.message import Message
+
+from frontrunner_sdk.clients.gas_estimators.table_gas_estimator import TableGasEstimator # NOQA
+
+
+class MultiplierTableGasEstimator(TableGasEstimator):
+  # Multiply per-message type gas estimates by the configured value
+
+  def __init__(self, multiplier: int):
+    self.multiplier = multiplier
+
+  async def gas_for(self, message: Message) -> int:
+    base_gas = await super().gas_for(message)
+
+    return base_gas * self.multiplier

--- a/frontrunner_sdk/clients/gas_estimators/multiplier_table_gas_estimator.py
+++ b/frontrunner_sdk/clients/gas_estimators/multiplier_table_gas_estimator.py
@@ -6,10 +6,10 @@ from frontrunner_sdk.clients.gas_estimators.table_gas_estimator import TableGasE
 class MultiplierTableGasEstimator(TableGasEstimator):
   # Multiply per-message type gas estimates by the configured value
 
-  def __init__(self, multiplier: int):
+  def __init__(self, multiplier: float):
     self.multiplier = multiplier
 
   async def gas_for(self, message: Message) -> int:
     base_gas = await super().gas_for(message)
 
-    return base_gas * self.multiplier
+    return int(base_gas * self.multiplier)

--- a/frontrunner_sdk/ioc.py
+++ b/frontrunner_sdk/ioc.py
@@ -8,6 +8,7 @@ from pyinjective.constant import Network
 
 from frontrunner_sdk.clients.denom_factory import DenomFactory
 from frontrunner_sdk.clients.gas_estimators.gas_estimator import GasEstimator
+from frontrunner_sdk.clients.gas_estimators.multiplier_table_gas_estimator import MultiplierTableGasEstimator # NOQA
 from frontrunner_sdk.clients.gas_estimators.offsetting_gas_estimator import OffsettingGasEstimator # NOQA
 from frontrunner_sdk.clients.gas_estimators.simulation_gas_estimator import SimulationGasEstimator # NOQA
 from frontrunner_sdk.clients.gas_estimators.table_gas_estimator import TableGasEstimator # NOQA
@@ -98,7 +99,7 @@ class FrontrunnerIoC(SyncMixin):
     # with simulation-based estimator instead, use...
     # estimator = SimulationGasEstimator(self.injective_client, self.network, self.wallet)
 
-    estimator = TableGasEstimator()
+    estimator = MultiplierTableGasEstimator(2)
     estimator = OffsettingGasEstimator(estimator)
     return estimator
 

--- a/tests/clients/gas_estimators/test_multiplier_table_gas_estimator.py
+++ b/tests/clients/gas_estimators/test_multiplier_table_gas_estimator.py
@@ -1,0 +1,52 @@
+from unittest import IsolatedAsyncioTestCase
+
+from pyinjective.proto.injective.exchange.v1beta1.exchange_pb2 import DerivativeOrder # NOQA
+from pyinjective.proto.injective.exchange.v1beta1.tx_pb2 import MsgBatchUpdateOrders # NOQA
+from pyinjective.proto.injective.exchange.v1beta1.tx_pb2 import MsgCreateSpotMarketOrder # NOQA
+from pyinjective.proto.injective.exchange.v1beta1.tx_pb2 import MsgDeposit
+from pyinjective.proto.injective.exchange.v1beta1.tx_pb2 import MsgRewardsOptOut # NOQA
+from pyinjective.proto.injective.exchange.v1beta1.tx_pb2 import OrderData
+
+from frontrunner_sdk.clients.gas_estimators.multiplier_table_gas_estimator import MultiplierTableGasEstimator # NOQA
+from frontrunner_sdk.clients.gas_estimators.table_gas_estimator import TableGasEstimator # NOQA
+from frontrunner_sdk.exceptions import FrontrunnerInjectiveException
+
+
+class TestOffsettingTableGasEstimator(IsolatedAsyncioTestCase):
+
+  def setUp(self):
+    self.estimator = MultiplierTableGasEstimator(2)
+
+  async def test_gas_for_unknown_message(self):
+    msg = MsgRewardsOptOut()
+
+    with self.assertRaises(FrontrunnerInjectiveException):
+      await self.estimator.gas_for(msg)
+
+  async def test_gas_for_unknown_order(self):
+    msg = MsgCreateSpotMarketOrder()
+
+    with self.assertRaises(FrontrunnerInjectiveException):
+      await self.estimator.gas_for(msg)
+
+  async def test_gas_for_non_composite_message(self):
+    msg = MsgDeposit()
+
+    self.assertEqual(
+      self.estimator.multiplier * TableGasEstimator.MESSAGE_RATES["MsgDeposit"],
+      await self.estimator.gas_for(msg),
+    )
+
+  async def test_gas_for_composite_message(self):
+    msg = MsgBatchUpdateOrders(
+      binary_options_orders_to_create=[DerivativeOrder(), DerivativeOrder()],
+      binary_options_orders_to_cancel=[OrderData()],
+    )
+
+    self.assertEqual(
+      self.estimator.multiplier * (
+        TableGasEstimator.MESSAGE_RATES["MsgBatchUpdateOrders"] + 2 * TableGasEstimator.ORDER_RATES["DerivativeOrder"] +
+        1 * TableGasEstimator.ORDER_RATES["OrderData"]
+      ),
+      await self.estimator.gas_for(msg),
+    )


### PR DESCRIPTION
This multiplies all per-message gas estimates by 2 (and keeps the additional 80k offset on top of the per-message gas estimates).